### PR TITLE
Ability to set registry by environment rather than config

### DIFF
--- a/lib/auditPackage.js
+++ b/lib/auditPackage.js
@@ -36,7 +36,7 @@ function auditPackage(pkgPath, cb) {
             if (err) {
                 return cb(err);
             }
-            registryBaseURL = config.get('registry');
+            registryBaseURL = process.env.NSP_REGISTRY || config.get('registry');
             registry = new RegClient(config);
             filterPackage(pkg, vulnerable, returnResults);
         }


### PR DESCRIPTION
Hi
We have quite a complicated registry setup and I don't want to use the registry defined in ~/.npmrc for the purpose of these checks, subsequently I've added a simple switch to use an environment variable (NSP_REGISTRY) instead if available.

Karl