### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,22 +7,22 @@
     "requiresafe": "bin/requiresafe"
   },
   "dependencies": {
-    "chalk": "^1.1.1",
-    "es6-promise": "^3.0.2",
-    "find-root": "^0.1.1",
-    "inquirer": "^0.10.0",
-    "is-email": "^0.1.1",
-    "jsonwebtoken": "^5.0.5",
-    "minimist": "^1.2.0",
-    "rc": "^1.1.1",
-    "requiresafe-sdk": "^3.0.0",
-    "semver": "^5.0.3"
+    "chalk": "1.1.1",
+    "es6-promise": "3.0.2",
+    "find-root": "0.1.1",
+    "inquirer": "0.10.1",
+    "is-email": "0.1.1",
+    "jsonwebtoken": "5.0.5",
+    "minimist": "1.2.0",
+    "rc": "1.1.1",
+    "requiresafe-sdk": "3.0.4",
+    "semver": "5.0.3"
   },
   "devDependencies": {
-    "@liftsecurity/pre-commit": "^1.0.1",
-    "code": "^1.2.1",
-    "lab": "^5.2.0",
-    "shrinkydink": "^1.0.0"
+    "@liftsecurity/pre-commit": "1.0.1",
+    "code": "1.5.0",
+    "lab": "5.18.1",
+    "shrinkydink": "1.0.0"
   },
   "keywords": [
     "security",


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
