### PR TITLE
fix reading proxy url from env var

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -56,7 +56,7 @@ module.exports = function (options, callback) {
     options = {};
   }
 
-  options.proxy = options.proxy || Conf.proxy;
+  options.proxy = options.proxy || Conf.proxy || process.env.https_proxy || process.env.HTTPS_PROXY;
   if (options.proxy) {
     Conf.api.agent = new ProxyAgent(options.proxy);
     delete options.proxy;


### PR DESCRIPTION
We have a lot of projects that we run NSP for before deploying and our build server already uses env vars for proxy settings for all the other tools we use like npm, bower, git, etc. It would be a lot easier for us if NSP would also check env vars for proxy settings as opposed to adding an `.nsprc` file to each of our projects.

NOTE: lab actually code coverage actually **fails** claiming that the `process.env.http_proxy` condition is always true.  This is not the case and I can't figure out why it reports that.  If someone can explain to me why, I would gladly update the pull request if you guys think these changes should make it into the project.
