### PR TITLE
Updates for Code Climate platform interoperability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN apk --update add nodejs curl && \
     npm install && \
     npm run setup-offline
 
-CMD ["/app/bin/nsp", "check", "--offline", "-o", "codeclimate"]
+CMD ["/app/bin/nsp", "check", "--offline", "--warn-only", "-o", "codeclimate"]

--- a/lib/check.js
+++ b/lib/check.js
@@ -88,7 +88,8 @@ module.exports = function (options, callback) {
   if (typeof options.package === 'string') {
     try {
       options.package = require(options.package);
-    } catch (e) {
+    }
+    catch (e) {
       return callback(e);
     }
   }
@@ -97,7 +98,8 @@ module.exports = function (options, callback) {
     try {
       shrinkwrap = options.shrinkwrap;
       options.shrinkwrap = require(options.shrinkwrap);
-    } catch (e) {
+    }
+    catch (e) {
       delete options.shrinkwrap;
     }
   }
@@ -115,7 +117,8 @@ module.exports = function (options, callback) {
       else {
         advisories = require('../advisories');
       }
-    } catch (e) {
+    }
+    catch (e) {
       return callback(new Error('Offline mode requires a local advisories.json'));
     }
 

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -13,7 +13,8 @@ var onCommand = function (args) {
   if (typeof args.output !== 'function') {
     if (Formatters[args.output]) {
       args.output = Formatters[args.output];
-    } else {
+    }
+    else {
       args.output = Formatters.default;
     }
   }
@@ -24,16 +25,17 @@ var onCommand = function (args) {
   Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, offline: args.offline }, function (err, result) {
 
     var output = args.output(err, result);
-    var exitCode = (err || result.length) ? 1 : 0;
+    var exitCode = (err || (result.length && !args['warn-only'])) ? 1 : 0;
 
     if (output) {
       if (exitCode) {
         console.error(output);
-      } else {
+      }
+      else {
         console.log(output);
       }
     }
-    return process.exit(args['warn-only'] ? 0 : exitCode);
+    return process.exit(exitCode);
   });
 };
 
@@ -53,6 +55,3 @@ module.exports = {
   ],
   command: onCommand
 };
-
-
-

--- a/lib/formatters/codeclimate.js
+++ b/lib/formatters/codeclimate.js
@@ -17,6 +17,7 @@ module.exports = function (err, data) {
       check_name: 'Vulnerable module "' + data[i].module + '" identified',
       description: '`' + data[i].module + '` ' + data[i].title,
       categories: ['Security'],
+      remediation_points: 300000,
       content: {
         body: data[i].content
       },


### PR DESCRIPTION
The Code Climate platforms requires a successful analysis run to exit with code 0 and write its results to STDOUT and a failed engine run to exit with code 1 and write debug information to STDERR. A recent refactoring to exit code and output handling changed this behavior such that errors could be written to STDOUT and a successful analysis could exit with code 1 if --warn-only wasn't passed.

This changes nsp behavior to always write vulnerability results to STDOUT and exit with code 0 if --warn-only is passed. It also ensures that if an error is raised, output will be written to STDERR and nsp exits with code 1.
- Change brace style to squash ESLint warnings
- Add remediation points to issues
- Pass --warn-only to nsp in Dockerfile
