### PR TITLE
Return error message in Code Climate runs

### DIFF
--- a/lib/formatters/codeclimate.js
+++ b/lib/formatters/codeclimate.js
@@ -3,7 +3,7 @@
 module.exports = function (err, data) {
 
   if (err) {
-    return 'Debug output: %j' + JSON.stringify(data) + '\n' + JSON.stringify(err);
+    return err.stack;
   }
 
   if (!data.length) {


### PR DESCRIPTION
Stringifying an Error object results in {} so the formatter was not
returning the actual underlying error with the Code Climate formatter.
This change returns the error so that they user can take action if an
analysis run fails.
