### PR TITLE
Add --subdep-warn-only option

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -197,7 +197,7 @@ module.exports = function (options, callback) {
         }
       }
 
-      return callback(null, results);
+      return callback(null, results, options.package.name);
     });
   }
   else {
@@ -214,7 +214,7 @@ module.exports = function (options, callback) {
         err = new Error('Got an invalid response from Node Security, please email the above debug output to support@nodesecurity.io');
       }
 
-      callback(err, payload);
+      callback(err, payload, options.package.name);
     });
   }
 };

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -26,9 +26,10 @@ var onCommand = function (args) {
 
     var output = args.output(err, result);
 
-    if(!err && args['subdep-warn-only']) {
+    if (!err && args['subdep-warn-only']) {
       // Only the package direct dependencies should impact the status code
-      result = result.filter(function(entry) {
+      result = result.filter(function (entry) {
+
         return entry.path[0] === rootPackageName;
       });
     }

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -22,9 +22,17 @@ var onCommand = function (args) {
   var pkgPath = Path.join(process.cwd(), 'package.json');
   var shrinkwrapPath = Path.join(process.cwd(), 'npm-shrinkwrap.json');
 
-  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, offline: args.offline }, function (err, result) {
+  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, offline: args.offline }, function (err, result, rootPackageName) {
 
     var output = args.output(err, result);
+
+    if(!err && args['subdep-warn-only']) {
+      // Only the package direct dependencies should impact the status code
+      result = result.filter(function(entry) {
+        return entry.path[0] === rootPackageName;
+      });
+    }
+
     var exitCode = (err || (result.length && !args['warn-only'])) ? 1 : 0;
 
     if (output) {
@@ -49,6 +57,11 @@ module.exports = {
     },
     {
       name: 'warn-only',
+      boolean: true,
+      default: false
+    },
+    {
+      name: 'subdep-warn-only',
       boolean: true,
       default: false
     }

--- a/usage/check.txt
+++ b/usage/check.txt
@@ -20,3 +20,7 @@ Parameters
   --warn-only: optional
 
     report errors, but always quit with an exit code of 0
+
+  --subdep-warn-only: optional
+
+    report errors, but only use direct dependencies to calculate the exit code


### PR DESCRIPTION
We are using nsp as a build checker (with https://github.com/FGRibreau/check-build) and it's great to see the vulnerabilities found in sub-dependencies, but we can't always afford to fix them.
