### PR TITLE
Make `advisoriesPath` option configurable

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -69,7 +69,7 @@ module.exports = function (options, callback) {
   var offline = options.offline;
   delete options.offline;
 
-  var advisoriesPath = options.advisoriesPath;
+  var advisoriesPath = options.advisoriesPath || Conf.advisoriesPath;
   delete options.advisoriesPath;
 
   if (!options.exceptions) {


### PR DESCRIPTION
In order to support a better offline experience, the `advisoriesPath` option
needs to be configurable so that the `advisories.json` file can be placed in
a directory that will persist across multiple runs (for CI purposes).
