### PR TITLE
Add a cli option for setting `advisoriesPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,13 @@ To configure the proxy set the proxy key in your `.nsprc` file. This can be put 
 ## Offline Mode
 nsp has an offline mode which was previously undocumented. We recommend not relying on offline support as it may become unsupported in the future as new features are added.
 
-1. In the directory in which the nsp module is installed run `npm run setup-offline`. If you are using nvm that di
-rectory might be something like `/Users/exampleuser/.nvm/versions/node/v4.2.1/lib/node_modules/nsp`
+1. In the directory in which the nsp module is installed run `npm run setup-offline`. If you are using nvm that
+directory might be something like `/Users/exampleuser/.nvm/versions/node/v4.2.1/lib/node_modules/nsp`
 
-1. Use the offline flag when you run nsp `nsp check --offline`
+2. Use the offline flag when you run nsp `nsp check --offline`
+
+3. Optionally specify an `advisoriesPath` either in `.nsprc` or as `--advisoriesPath` option that points to the
+full path of offline `advisories.json`.
 
 A couple of notes
 - Offline mode requires that your project include a npm-shrinkwrap.json file. 

--- a/lib/check.js
+++ b/lib/check.js
@@ -42,11 +42,12 @@ internals.optionSchema = Joi.object({
 }).or(['package', 'shrinkwrap']);
 
 /*
-options should be an object that contains one or more of the keys package, shrinkwrap, offline
+options should be an object that contains one or more of the keys package, shrinkwrap, offline, advisoriesPath
   {
     package: '/path/to/package.json',
     shrinkwrap: '/path/to/npm-shrinkwrap.json',
-    offline: false
+    offline: false,
+    advisoriesPath: undefined
   }
 */
 module.exports = function (options, callback) {

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -22,7 +22,7 @@ var onCommand = function (args) {
   var pkgPath = Path.join(process.cwd(), 'package.json');
   var shrinkwrapPath = Path.join(process.cwd(), 'npm-shrinkwrap.json');
 
-  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, offline: args.offline }, function (err, result) {
+  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, offline: args.offline, advisoriesPath: args.advisoriesPath }, function (err, result) {
 
     var output = args.output(err, result);
     var exitCode = (err || (result.length && !args['warn-only'])) ? 1 : 0;
@@ -50,6 +50,10 @@ module.exports = {
     {
       name: 'warn-only',
       boolean: true,
+      default: false
+    },
+    {
+      name: 'advisoriesPath',
       default: false
     }
   ],

--- a/usage/check.txt
+++ b/usage/check.txt
@@ -15,8 +15,12 @@ Parameters
 
   --offline: optional
 
-    when network is unavailable you can use this (but it won't have as many results as the online version)
+    when network is unavailable, you can use this
 
   --warn-only: optional
 
     report errors, but always quit with an exit code of 0
+
+  --advisoriesPath: optional
+
+    full path to advisories.json file for offline support


### PR DESCRIPTION
Permit passing `--advisoriesPath /path/to/advisories.json` to `nsp check --offline` in order to specify a custom location for the vulnerability data.
