### PR TITLE
README.md: Mention that .nsprc is parsed with `rc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The URLs used in the array should match the advisory link that the CLI reports. 
 
 Be careful using this feature. If you add code later that is impacted by an excluded advisory, Node Security has no way of knowing. Keep a careful eye on your exceptions.
 
+`.nsprc` is read using [rc](https://github.com/dominictarr/rc), so it supports comments using [json-strip-comments](https://github.com/sindresorhus/strip-json-comments).
+
 ## Proxy Support
 
 The Node Security CLI has proxy support by using [proxy-agent](https://www.npmjs.com/package/proxy-agent).


### PR DESCRIPTION
This was not at all obvious to me, as seen in #68.
