### PR TITLE
remove Dockerfile from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ test/
 node_modules
 npm-debug.log
 advisories.json
+Dockerfile


### PR DESCRIPTION
AFAIK it's only needed when developing--a garden-variety `npm install` shouldn't necessitate its inclusion, right?
