### PR TITLE
Fix ansi-styles dependency version in shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6,7 +6,7 @@
       "version": "1.1.1",
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "dependencies": {
             "color-convert": {
               "version": "1.0.0"


### PR DESCRIPTION
Updates ansi-styles dependency to use new version 2.2.1 (the previous 2.2.0 was removed https://github.com/chalk/ansi-styles/releases)
