### PR TITLE
Show output flag in formatting section of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ Node Security helps you keep your node applications secure. With Node Security y
 
 ## Output Format
 
-You can adjust how the client outputs findings by specifying one of the following format options.
+You can adjust how the client outputs findings by specifying one of the following format options:
 
 - default
 - summary
 - json
 - codeclimate
 - none
+
+Example: `nsp check --output summary`
 
 ## Exceptions
 


### PR DESCRIPTION
Show the `output` flag in an example in the formatting section of the README so users will know how to apply formatting options.
