### PR TITLE
offline check reports path correctly

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -202,7 +202,7 @@ module.exports = function (options, callback) {
 
       var results = [];
       for (var i = 0, il = vulns.length; i < il; ++i) {
-        var path = tree[vulns[i].module + '@' + vulns[i].version].parents;
+        var path = tree[vulns[i].module + '@' + vulns[i].version].paths;
         var line = internals.findLines(shrinkwrap, vulns[i].module, vulns[i].version);
         for (var x = 0, xl = vulns[i].vulnerabilities.length; x < xl; ++x) {
           results.push({


### PR DESCRIPTION
Offline check previously failed to report path correctly.

Lib/check was simply reading the wrong property (specifically, a non-existent property "parents" instead of "paths") from the tree returned by nodesecurity-npm-utils.

Weirdly enough, that project's documentation does specify that it returns "parents" and not "paths", even though the source (and obviously the end result) behaves otherwise. Perhaps a better pull request would be to that project and not this one to either align the docs with the code or vice versa. 

However, offline checks fail without this fix and succeeds with it, so I'm submitting it for your consideration. 
