### PR TITLE
updating joi to 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "chalk": "^1.1.1",
     "cli-table": "^0.3.1",
     "https-proxy-agent": "^1.0.0",
-    "joi": "^6.9.1",
+    "joi": "^8.0.0",
     "nodesecurity-npm-utils": "^4.0.1",
     "path-is-absolute": "^1.0.0",
     "rc": "^1.1.2",


### PR DESCRIPTION
Using nsp within atom throws a csp error(eval). This was due to module isemail which is used by joi. This was fixed in a later version of isemail which was picked by >7.x of joi
