### PR TITLE
Export shared getFormatter() method for grunt-nsp module

### DIFF
--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -3,20 +3,8 @@ var usage = require('../../lib/utils/usage.js')('check.txt');
 var Check = require('../check.js');
 var Formatters = require('../formatters');
 var Path = require('path');
+var getFormatter = require('../../lib/index').getFormatter;
 
-var getFormatter = function (name) {
-
-  if (Object.keys(Formatters).indexOf(name) !== -1) {
-    return Formatters[name];
-  }
-
-  try {
-    return require('nsp-formatter-' + name);
-  }
-  catch (e) {}
-
-  return Formatters.default;
-};
 
 var onCommand = function (args) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,22 @@
 'use strict';
 
+var Formatters = require('./formatters');
+
+var getFormatter = function (name) {
+  if (Object.keys(Formatters).indexOf(name) !== -1) {
+    return Formatters[name];
+  }
+
+  try {
+    return require('nsp-formatter-' + name);
+  }
+  catch (e) {}
+
+  return Formatters.default;
+};
+
 module.exports = {
   check: require('./check'),
-  formatters: require('./formatters')
+  formatters: Formatters,
+  getFormatter: getFormatter
 };


### PR DESCRIPTION
Ref: https://github.com/nodesecurity/grunt-nsp/issues/19

Saves having to copy-pasta that utility function to grunt-nsp and probably gulp-nsp.
