### PR TITLE
Support yarn.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ Second you need to tell nsp where to find that file. You can do that 3 ways.
 When you call nsp check you will want to use the --offline flag
 
 A couple of notes
-- Offline mode requires that your project include a npm-shrinkwrap.json file.
+- Offline mode requires that your project include a npm-shrinkwrap.json or yarn.lock file.
 - Because of npm3 flattening reported paths may be incorrect.
 
 ## Code Climate Node Security Engine
 
 `codeclimate-nodesecurity` is a Code Climate engine that wraps the Node Security CLI. You can run it on your command line using the Code Climate CLI, or Code Climate's <a href="http://codeclimate.com">hosted analysis platform</a>.
 
-Note that this engine *only* works if your code has a `npm-shrinkwrap.json` file committed.
+Note that this engine *only* works if your code has a `npm-shrinkwrap.json` or `yarn.lock` file committed.
 
 ### Testing
 

--- a/lib/check.js
+++ b/lib/check.js
@@ -241,6 +241,7 @@ module.exports = function (options, callback) {
     if (options.shrinkwrap && !options.shrinkwrap.name) {
       options.shrinkwrap.name = options.package.name;
     }
+    delete options.yarnlock;
     wreck.post('/check', { payload: JSON.stringify(options) }, function (err, res, payload) {
 
       if (err) {

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,7 +9,7 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
-var parseYarnLock = require('yarn/lib-legacy/lockfile/parse').default;
+var parseYarnLock = require('yarn/lib-es5/lockfile/parse').default;
 
 var Conf = require('rc')('nsp', {
   api: {

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,7 +9,7 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
-var parseYarnLock = require('yarn/lib-es5/lockfile/parse').default;
+var parseYarnLock = require('yarn/lib-legacy/lockfile/parse').default;
 
 var Conf = require('rc')('nsp', {
   api: {

--- a/lib/check.js
+++ b/lib/check.js
@@ -127,7 +127,6 @@ module.exports = function (options, callback) {
   else {
     shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
   }
-
   if (!options.shrinkwrap) {
     if (options.yarnlock) {
       var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
@@ -139,7 +138,7 @@ module.exports = function (options, callback) {
   if (offline) {
     var advisories;
     if (!options.shrinkwrap) {
-      return callback(new Error('npm-shrinkwrap.json is required for offline mode'));
+      return callback(new Error('npm-shrinkwrap.json / yarn.lock is required for offline mode'));
     }
     try {
       if (advisoriesPath) {
@@ -238,6 +237,9 @@ module.exports = function (options, callback) {
   else {
     if (!options.package) {
       return callback(new Error('package.json is required'));
+    }
+    if (options.shrinkwrap && !options.shrinkwrap.name) {
+      options.shrinkwrap.name = options.package.name;
     }
     wreck.post('/check', { payload: JSON.stringify(options) }, function (err, res, payload) {
 

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,6 +9,7 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
+var parseYarnLock = require('yarn/lib/lockfile/parse').default;
 
 var Conf = require('rc')('nsp', {
   api: {
@@ -42,11 +43,16 @@ internals.findLines = function (shrinkwrap, module, version) {
   };
 };
 
+internals.stringifyShrinkwrap = function (shrinkwrap) {
+  return JSON.stringify(shrinkwrap, null, 2);
+};
+
 internals.exceptionRegex = /^https\:\/\/nodesecurity\.io\/advisories\/([0-9]+)$/;
 
 internals.optionSchema = Joi.object({
   package: Joi.alternatives().try(Joi.string(), Joi.object()),
   shrinkwrap: Joi.alternatives().try(Joi.string(), Joi.object()),
+  yarnlock: Joi.string(),
   exceptions: Joi.array().items(Joi.string().regex(internals.exceptionRegex)).default([]),
   advisoriesPath: Joi.string(),
   proxy: Joi.string()
@@ -119,12 +125,19 @@ module.exports = function (options, callback) {
     }
   }
   else {
-    shrinkwrap = JSON.stringify(options.shrinkwrap, null, 2);
+    shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
+  }
+
+  if (!options.shrinkwrap) {
+    if (options.yarnlock) {
+      var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
+      options.shrinkwrap = { dependencies: parseYarnLock(yarnlock) };
+      shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
+    }
   }
 
   if (offline) {
     var advisories;
-
     if (!options.shrinkwrap) {
       return callback(new Error('npm-shrinkwrap.json is required for offline mode'));
     }

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,7 +9,7 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
-var parseYarnLock = require('yarn/lib/lockfile/parse').default;
+var parseYarnLock = require('yarn/lib-legacy/lockfile/parse').default;
 
 var Conf = require('rc')('nsp', {
   api: {

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -18,8 +18,9 @@ var onCommand = function (args) {
 
   var pkgPath = Path.join(process.cwd(), 'package.json');
   var shrinkwrapPath = Path.join(process.cwd(), 'npm-shrinkwrap.json');
+  var yarnLockPath = Path.join(process.cwd(), 'yarn.lock');
 
-  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, offline: args.offline, advisoriesPath: args.advisoriesPath }, function (err, result) {
+  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, yarnlock: yarnLockPath, offline: args.offline, advisoriesPath: args.advisoriesPath }, function (err, result) {
 
     var file = args.offline ? shrinkwrapPath : pkgPath;
     var output = args.output(err, result, file);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,281 +4,437 @@
   "dependencies": {
     "chalk": {
       "version": "1.1.3",
+      "from": "chalk@1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.1"
+          "version": "2.2.1",
+          "from": "ansi-styles@2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
         },
         "escape-string-regexp": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "from": "escape-string-regexp@1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
+          "from": "has-ansi@2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "from": "ansi-regex@2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             }
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "from": "strip-ansi@3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "from": "ansi-regex@2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             }
           }
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "supports-color@2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "cli-table": {
       "version": "0.3.1",
+      "from": "cli-table@0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "dependencies": {
         "colors": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "from": "colors@1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
         }
       }
     },
     "https-proxy-agent": {
       "version": "1.0.0",
+      "from": "https-proxy-agent@1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "dependencies": {
         "agent-base": {
           "version": "2.0.1",
+          "from": "agent-base@2.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
           "dependencies": {
             "semver": {
-              "version": "5.0.3"
+              "version": "5.0.3",
+              "from": "semver@5.0.3",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
             }
           }
         },
         "debug": {
           "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
-              "version": "0.7.1"
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "extend": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "from": "extend@3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         }
       }
     },
     "joi": {
       "version": "6.10.1",
+      "from": "joi@6.10.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.16.3"
+          "version": "2.16.3",
+          "from": "hoek@2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "topo": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "from": "topo@1.1.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
         },
         "isemail": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "from": "isemail@1.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
         },
         "moment": {
-          "version": "2.12.0"
+          "version": "2.12.0",
+          "from": "moment@2.12.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
         }
       }
     },
     "nodesecurity-npm-utils": {
-      "version": "5.0.0"
+      "version": "5.0.0",
+      "from": "nodesecurity-npm-utils@5.0.0",
+      "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz"
     },
     "path-is-absolute": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "path-is-absolute@1.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "rc": {
       "version": "1.1.6",
+      "from": "rc@1.1.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
       "dependencies": {
         "deep-extend": {
-          "version": "0.4.1"
+          "version": "0.4.1",
+          "from": "deep-extend@0.4.1",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
         },
         "ini": {
-          "version": "1.3.4"
+          "version": "1.3.4",
+          "from": "ini@1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
         "minimist": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "from": "minimist@1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "strip-json-comments": {
-          "version": "1.0.4"
+          "version": "1.0.4",
+          "from": "strip-json-comments@1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         }
       }
     },
     "semver": {
-      "version": "5.1.0"
+      "version": "5.1.0",
+      "from": "semver@5.1.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
     "subcommand": {
       "version": "2.0.3",
+      "from": "subcommand@2.0.3",
+      "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
       "dependencies": {
         "cliclopts": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "from": "cliclopts@1.1.1",
+          "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz"
         },
         "debug": {
           "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
-              "version": "0.7.1"
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "minimist": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "xtend": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "from": "xtend@4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "wreck": {
       "version": "6.3.0",
+      "from": "wreck@6.3.0",
+      "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.16.3"
+          "version": "2.16.3",
+          "from": "hoek@2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "boom": {
-          "version": "2.10.1"
+          "version": "2.10.1",
+          "from": "boom@2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         }
       }
     },
     "yarn": {
-      "version": "0.17.10",
+      "version": "0.19.0-0",
+      "from": "methyl/yarn",
+      "resolved": "git://github.com/methyl/yarn.git#56e790fab9d218099e17e3170cc4c37d63d5b586",
       "dependencies": {
         "babel-runtime": {
           "version": "6.20.0",
+          "from": "babel-runtime@>=6.0.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
           "dependencies": {
             "core-js": {
-              "version": "2.4.1"
+              "version": "2.4.1",
+              "from": "core-js@>=2.4.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
             },
             "regenerator-runtime": {
-              "version": "0.10.1"
+              "version": "0.10.1",
+              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
             }
           }
         },
         "bytes": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "from": "bytes@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
         },
         "camelcase": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
         },
         "cmd-shim": {
           "version": "2.0.2",
+          "from": "cmd-shim@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
           "dependencies": {
             "graceful-fs": {
-              "version": "4.1.11"
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             }
           }
         },
         "commander": {
           "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dependencies": {
             "graceful-readlink": {
-              "version": "1.0.1"
+              "version": "1.0.1",
+              "from": "graceful-readlink@>=1.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "death": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "death@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/death/-/death-1.0.0.tgz"
         },
         "debug": {
           "version": "2.4.4",
+          "from": "debug@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.4.4.tgz",
           "dependencies": {
             "ms": {
-              "version": "0.7.2"
+              "version": "0.7.2",
+              "from": "ms@0.7.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
             }
           }
         },
         "defaults": {
           "version": "1.0.3",
+          "from": "defaults@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
           "dependencies": {
             "clone": {
-              "version": "1.0.2"
+              "version": "1.0.2",
+              "from": "clone@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
             }
           }
         },
         "detect-indent": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "from": "detect-indent@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
         },
         "diff": {
-          "version": "2.2.3"
+          "version": "2.2.3",
+          "from": "diff@>=2.2.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
         },
         "ini": {
-          "version": "1.3.4"
+          "version": "1.3.4",
+          "from": "ini@>=1.3.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
         "inquirer": {
           "version": "1.2.3",
+          "from": "inquirer@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
           "dependencies": {
             "ansi-escapes": {
-              "version": "1.4.0"
+              "version": "1.4.0",
+              "from": "ansi-escapes@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
             },
             "cli-cursor": {
               "version": "1.0.2",
+              "from": "cli-cursor@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
               "dependencies": {
                 "restore-cursor": {
                   "version": "1.0.1",
+                  "from": "restore-cursor@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                   "dependencies": {
                     "exit-hook": {
-                      "version": "1.1.1"
+                      "version": "1.1.1",
+                      "from": "exit-hook@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
                     },
                     "onetime": {
-                      "version": "1.1.0"
+                      "version": "1.1.0",
+                      "from": "onetime@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
                     }
                   }
                 }
               }
             },
             "cli-width": {
-              "version": "2.1.0"
+              "version": "2.1.0",
+              "from": "cli-width@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
             },
             "external-editor": {
               "version": "1.1.1",
+              "from": "external-editor@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
               "dependencies": {
                 "extend": {
-                  "version": "3.0.0"
+                  "version": "3.0.0",
+                  "from": "extend@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "spawn-sync": {
                   "version": "1.0.15",
+                  "from": "spawn-sync@>=1.0.15 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.5.2",
+                      "from": "concat-stream@>=1.4.7 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
                       "dependencies": {
                         "inherits": {
-                          "version": "2.0.3"
+                          "version": "2.0.3",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "typedarray": {
-                          "version": "0.0.6"
+                          "version": "0.0.6",
+                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "2.0.6",
+                          "from": "readable-stream@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.2"
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
-                              "version": "1.0.0"
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             },
                             "process-nextick-args": {
-                              "version": "1.0.7"
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                             },
                             "string_decoder": {
-                              "version": "0.10.31"
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "util-deprecate": {
-                              "version": "1.0.2"
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
                         }
                       }
                     },
                     "os-shim": {
-                      "version": "0.1.3"
+                      "version": "0.1.3",
+                      "from": "os-shim@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
                     }
                   }
                 },
                 "tmp": {
                   "version": "0.0.29",
+                  "from": "tmp@>=0.0.29 <0.0.30",
+                  "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
                   "dependencies": {
                     "os-tmpdir": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "os-tmpdir@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
                     }
                   }
                 }
@@ -286,51 +442,79 @@
             },
             "figures": {
               "version": "1.7.0",
+              "from": "figures@>=1.3.5 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
               "dependencies": {
                 "escape-string-regexp": {
-                  "version": "1.0.5"
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "object-assign": {
-                  "version": "4.1.0"
+                  "version": "4.1.0",
+                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 }
               }
             },
             "lodash": {
-              "version": "4.17.2"
+              "version": "4.17.2",
+              "from": "lodash@>=4.3.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
             },
             "mute-stream": {
-              "version": "0.0.6"
+              "version": "0.0.6",
+              "from": "mute-stream@0.0.6",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
             },
             "pinkie-promise": {
               "version": "2.0.1",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "dependencies": {
                 "pinkie": {
-                  "version": "2.0.4"
+                  "version": "2.0.4",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
             },
             "run-async": {
               "version": "2.3.0",
+              "from": "run-async@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
               "dependencies": {
                 "is-promise": {
-                  "version": "2.1.0"
+                  "version": "2.1.0",
+                  "from": "is-promise@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
                 }
               }
             },
             "rx": {
-              "version": "4.1.0"
+              "version": "4.1.0",
+              "from": "rx@>=4.1.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
             },
             "string-width": {
               "version": "1.0.2",
+              "from": "string-width@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "dependencies": {
                 "code-point-at": {
-                  "version": "1.1.0"
+                  "version": "1.1.0",
+                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
+                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.1"
+                      "version": "1.0.1",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     }
                   }
                 }
@@ -338,25 +522,37 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "through": {
-              "version": "2.3.8"
+              "version": "2.3.8",
+              "from": "through@>=2.3.6 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "invariant": {
           "version": "2.2.2",
+          "from": "invariant@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
           "dependencies": {
             "loose-envify": {
               "version": "1.3.0",
+              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
               "dependencies": {
                 "js-tokens": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "from": "js-tokens@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
                 }
               }
             }
@@ -364,50 +560,76 @@
         },
         "is-builtin-module": {
           "version": "1.0.0",
+          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "dependencies": {
             "builtin-modules": {
-              "version": "1.1.1"
+              "version": "1.1.1",
+              "from": "builtin-modules@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
             }
           }
         },
         "is-ci": {
           "version": "1.0.10",
+          "from": "is-ci@>=1.0.10 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
           "dependencies": {
             "ci-info": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "from": "ci-info@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz"
             }
           }
         },
         "leven": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "leven@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.0.0.tgz"
         },
         "loud-rejection": {
           "version": "1.6.0",
+          "from": "loud-rejection@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
           "dependencies": {
             "currently-unhandled": {
               "version": "0.4.1",
+              "from": "currently-unhandled@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
               "dependencies": {
                 "array-find-index": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "array-find-index@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
                 }
               }
             },
             "signal-exit": {
-              "version": "3.0.2"
+              "version": "3.0.2",
+              "from": "signal-exit@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
             }
           }
         },
         "minimatch": {
           "version": "3.0.3",
+          "from": "minimatch@>=3.0.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.6",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
               "dependencies": {
                 "balanced-match": {
-                  "version": "0.4.2"
+                  "version": "0.4.2",
+                  "from": "balanced-match@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                 },
                 "concat-map": {
-                  "version": "0.0.1"
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -415,138 +637,216 @@
         },
         "mkdirp": {
           "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
-              "version": "0.0.8"
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "node-emoji": {
           "version": "1.4.3",
+          "from": "node-emoji@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.3.tgz",
           "dependencies": {
             "string.prototype.codepointat": {
-              "version": "0.2.0"
+              "version": "0.2.0",
+              "from": "string.prototype.codepointat@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz"
             }
           }
         },
         "node-gyp": {
           "version": "3.4.0",
+          "from": "node-gyp@>=3.2.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
           "dependencies": {
             "fstream": {
               "version": "1.0.10",
+              "from": "fstream@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.3"
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
             "glob": {
               "version": "7.1.1",
+              "from": "glob@>=7.0.3 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "dependencies": {
                 "fs.realpath": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
                   "version": "1.0.6",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.3"
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "once": {
                   "version": "1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
               }
             },
             "graceful-fs": {
-              "version": "4.1.11"
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             },
             "nopt": {
               "version": "3.0.6",
+              "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.9"
+                  "version": "1.0.9",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                 }
               }
             },
             "npmlog": {
               "version": "3.1.2",
+              "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
+                  "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
                   "dependencies": {
                     "delegates": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "from": "delegates@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
                     "readable-stream": {
                       "version": "2.2.2",
+                      "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
                       "dependencies": {
                         "buffer-shims": {
-                          "version": "1.0.0"
+                          "version": "1.0.0",
+                          "from": "buffer-shims@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                         },
                         "core-util-is": {
-                          "version": "1.0.2"
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
-                          "version": "1.0.0"
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "inherits": {
-                          "version": "2.0.3"
+                          "version": "2.0.3",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.7"
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
-                          "version": "0.10.31"
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
-                          "version": "1.0.2"
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     }
                   }
                 },
                 "console-control-strings": {
-                  "version": "1.1.0"
+                  "version": "1.1.0",
+                  "from": "console-control-strings@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
                 },
                 "gauge": {
                   "version": "2.6.0",
+                  "from": "gauge@>=2.6.0 <2.7.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
                   "dependencies": {
                     "aproba": {
-                      "version": "1.0.4"
+                      "version": "1.0.4",
+                      "from": "aproba@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
                     },
                     "has-color": {
-                      "version": "0.1.7"
+                      "version": "0.1.7",
+                      "from": "has-color@>=0.1.7 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
                     "has-unicode": {
-                      "version": "2.0.1"
+                      "version": "2.0.1",
+                      "from": "has-unicode@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
                     },
                     "object-assign": {
-                      "version": "4.1.0"
+                      "version": "4.1.0",
+                      "from": "object-assign@>=4.1.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                     },
                     "signal-exit": {
-                      "version": "3.0.2"
+                      "version": "3.0.2",
+                      "from": "signal-exit@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
                     },
                     "string-width": {
                       "version": "1.0.2",
+                      "from": "string-width@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                       "dependencies": {
                         "code-point-at": {
-                          "version": "1.1.0"
+                          "version": "1.1.0",
+                          "from": "code-point-at@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
+                          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                           "dependencies": {
                             "number-is-nan": {
-                              "version": "1.0.1"
+                              "version": "1.0.1",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                             }
                           }
                         }
@@ -554,50 +854,76 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "2.0.0"
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "wide-align": {
-                      "version": "1.1.0"
+                      "version": "1.1.0",
+                      "from": "wide-align@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
                     }
                   }
                 },
                 "set-blocking": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "from": "set-blocking@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.1.4",
+              "from": "osenv@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
               "dependencies": {
                 "os-homedir": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
                 },
                 "os-tmpdir": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
                 }
               }
             },
             "path-array": {
               "version": "1.0.1",
+              "from": "path-array@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
               "dependencies": {
                 "array-index": {
                   "version": "1.0.0",
+                  "from": "array-index@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "3.1.0",
+                      "from": "es6-symbol@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
                       "dependencies": {
                         "d": {
-                          "version": "0.1.1"
+                          "version": "0.1.1",
+                          "from": "d@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                         },
                         "es5-ext": {
                           "version": "0.10.12",
+                          "from": "es5-ext@>=0.10.11 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
                           "dependencies": {
                             "es6-iterator": {
-                              "version": "2.0.0"
+                              "version": "2.0.0",
+                              "from": "es6-iterator@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                             }
                           }
                         }
@@ -609,50 +935,76 @@
             },
             "which": {
               "version": "1.2.12",
+              "from": "which@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
               "dependencies": {
                 "isexe": {
-                  "version": "1.1.2"
+                  "version": "1.1.2",
+                  "from": "isexe@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                 }
               }
             }
           }
         },
         "object-path": {
-          "version": "0.11.3"
+          "version": "0.11.3",
+          "from": "object-path@>=0.11.2 <0.12.0",
+          "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.3.tgz"
         },
         "proper-lockfile": {
           "version": "1.2.0",
+          "from": "proper-lockfile@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "dependencies": {
             "err-code": {
-              "version": "1.1.1"
+              "version": "1.1.1",
+              "from": "err-code@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.1.tgz"
             },
             "extend": {
-              "version": "3.0.0"
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "graceful-fs": {
-              "version": "4.1.11"
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             },
             "retry": {
-              "version": "0.10.1"
+              "version": "0.10.1",
+              "from": "retry@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz"
             }
           }
         },
         "read": {
           "version": "1.0.7",
+          "from": "read@>=1.0.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
           "dependencies": {
             "mute-stream": {
-              "version": "0.0.6"
+              "version": "0.0.6",
+              "from": "mute-stream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
             }
           }
         },
         "repeating": {
           "version": "2.0.1",
+          "from": "repeating@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.2",
+              "from": "is-finite@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
               "dependencies": {
                 "number-is-nan": {
-                  "version": "1.0.1"
+                  "version": "1.0.1",
+                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                 }
               }
             }
@@ -660,68 +1012,106 @@
         },
         "request": {
           "version": "2.79.0",
+          "from": "request@>=2.75.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "dependencies": {
             "aws-sign2": {
-              "version": "0.6.0"
+              "version": "0.6.0",
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
-              "version": "1.5.0"
+              "version": "1.5.0",
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
             },
             "caseless": {
-              "version": "0.11.0"
+              "version": "0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
-              "version": "3.0.0"
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
-              "version": "0.6.1"
+              "version": "0.6.1",
+              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "2.1.2",
+              "from": "form-data@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
               "dependencies": {
                 "asynckit": {
-                  "version": "0.4.0"
+                  "version": "0.4.0",
+                  "from": "asynckit@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
+              "from": "har-validator@>=2.0.6 <2.1.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
                 "is-my-json-valid": {
                   "version": "2.15.0",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
                   "dependencies": {
                     "generate-function": {
-                      "version": "2.0.0"
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
-                          "version": "1.0.2"
+                          "version": "1.0.2",
+                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
-                      "version": "4.0.0"
+                      "version": "4.0.0",
+                      "from": "jsonpointer@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
                     },
                     "xtend": {
-                      "version": "4.0.1"
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
-                      "version": "2.0.4"
+                      "version": "2.0.4",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 }
@@ -729,145 +1119,229 @@
             },
             "hawk": {
               "version": "3.1.3",
+              "from": "hawk@>=3.1.3 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.16.3"
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
-                  "version": "2.10.1"
+                  "version": "2.10.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
-                  "version": "2.0.5"
+                  "version": "2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
-                  "version": "1.0.9"
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
+              "from": "http-signature@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "dependencies": {
                 "assert-plus": {
-                  "version": "0.2.0"
+                  "version": "0.2.0",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.3.1",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                   "dependencies": {
                     "extsprintf": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
-                      "version": "0.2.3"
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                     },
                     "verror": {
-                      "version": "1.3.6"
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.10.1",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
                   "dependencies": {
                     "asn1": {
-                      "version": "0.2.3"
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "assert-plus": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "dashdash": {
-                      "version": "1.14.1"
+                      "version": "1.14.1",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                     },
                     "getpass": {
-                      "version": "0.1.6"
+                      "version": "0.1.6",
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                     },
                     "jsbn": {
-                      "version": "0.1.0"
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
-                      "version": "0.14.5"
+                      "version": "0.14.5",
+                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                     },
                     "jodid25519": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "ecc-jsbn": {
-                      "version": "0.1.1"
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
                     "bcrypt-pbkdf": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
                     }
                   }
                 }
               }
             },
             "is-typedarray": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
-              "version": "0.1.2"
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
-              "version": "5.0.1"
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.13",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.25.0"
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
             },
             "oauth-sign": {
-              "version": "0.8.2"
+              "version": "0.8.2",
+              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
             },
             "qs": {
-              "version": "6.3.0"
+              "version": "6.3.0",
+              "from": "qs@>=6.3.0 <6.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
             },
             "stringstream": {
-              "version": "0.0.5"
+              "version": "0.0.5",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
               "version": "2.3.2",
+              "from": "tough-cookie@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
               "dependencies": {
                 "punycode": {
-                  "version": "1.4.1"
+                  "version": "1.4.1",
+                  "from": "punycode@>=1.4.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                 }
               }
             },
             "tunnel-agent": {
-              "version": "0.4.3"
+              "version": "0.4.3",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             },
             "uuid": {
-              "version": "3.0.1"
+              "version": "3.0.1",
+              "from": "uuid@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
             }
           }
         },
         "request-capture-har": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "from": "request-capture-har@>=1.1.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/request-capture-har/-/request-capture-har-1.1.4.tgz"
         },
         "rimraf": {
           "version": "2.5.4",
+          "from": "rimraf@>=2.5.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
           "dependencies": {
             "glob": {
               "version": "7.1.1",
+              "from": "glob@>=7.0.5 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "dependencies": {
                 "fs.realpath": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
                   "version": "1.0.6",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.3"
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "once": {
                   "version": "1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
@@ -876,61 +1350,95 @@
           }
         },
         "roadrunner": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "from": "roadrunner@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/roadrunner/-/roadrunner-1.1.0.tgz"
         },
         "strip-bom": {
           "version": "2.0.0",
+          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "dependencies": {
             "is-utf8": {
-              "version": "0.2.1"
+              "version": "0.2.1",
+              "from": "is-utf8@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
             }
           }
         },
         "tar": {
           "version": "2.2.1",
+          "from": "tar@>=2.2.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "dependencies": {
             "block-stream": {
-              "version": "0.0.9"
+              "version": "0.0.9",
+              "from": "block-stream@*",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
             },
             "fstream": {
               "version": "1.0.10",
+              "from": "fstream@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "4.1.11"
+                  "version": "4.1.11",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                 }
               }
             },
             "inherits": {
-              "version": "2.0.3"
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
         },
         "tar-stream": {
           "version": "1.5.2",
+          "from": "tar-stream@>=1.5.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
           "dependencies": {
             "bl": {
               "version": "1.1.2",
+              "from": "bl@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.3"
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.7"
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
-                      "version": "0.10.31"
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 }
@@ -938,12 +1446,18 @@
             },
             "end-of-stream": {
               "version": "1.1.0",
+              "from": "end-of-stream@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
@@ -951,56 +1465,86 @@
             },
             "readable-stream": {
               "version": "2.2.2",
+              "from": "readable-stream@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
               "dependencies": {
                 "buffer-shims": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "buffer-shims@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                 },
                 "core-util-is": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.3"
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.7"
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
-                  "version": "0.10.31"
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
-              "version": "4.0.1"
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "user-home": {
           "version": "2.0.0",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "dependencies": {
             "os-homedir": {
-              "version": "1.0.2"
+              "version": "1.0.2",
+              "from": "os-homedir@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
+          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
+              "from": "spdx-correct@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
               "dependencies": {
                 "spdx-license-ids": {
-                  "version": "1.2.2"
+                  "version": "1.2.2",
+                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
                 }
               }
             },
             "spdx-expression-parse": {
-              "version": "1.0.4"
+              "version": "1.0.4",
+              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
             }
           }
         }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -139,6 +139,872 @@
           "version": "2.10.1"
         }
       }
+    },
+    "yarn": {
+      "version": "0.17.10",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.20.0",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1"
+            },
+            "regenerator-runtime": {
+              "version": "0.10.1"
+            }
+          }
+        },
+        "bytes": {
+          "version": "2.4.0"
+        },
+        "camelcase": {
+          "version": "3.0.0"
+        },
+        "cmd-shim": {
+          "version": "2.0.2",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.11"
+            }
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "death": {
+          "version": "1.0.0"
+        },
+        "debug": {
+          "version": "2.4.4",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.2"
+            }
+          }
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2"
+            }
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0"
+        },
+        "diff": {
+          "version": "2.2.3"
+        },
+        "ini": {
+          "version": "1.3.4"
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0"
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1"
+                    },
+                    "onetime": {
+                      "version": "1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "2.1.0"
+            },
+            "external-editor": {
+              "version": "1.1.1",
+              "dependencies": {
+                "extend": {
+                  "version": "3.0.0"
+                },
+                "spawn-sync": {
+                  "version": "1.0.15",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.5.2",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.3"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.6",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2"
+                            },
+                            "isarray": {
+                              "version": "1.0.0"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "os-shim": {
+                      "version": "0.1.3"
+                    }
+                  }
+                },
+                "tmp": {
+                  "version": "0.0.29",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.5"
+                },
+                "object-assign": {
+                  "version": "4.1.0"
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.17.2"
+            },
+            "mute-stream": {
+              "version": "0.0.6"
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "dependencies": {
+                "pinkie": {
+                  "version": "2.0.4"
+                }
+              }
+            },
+            "run-async": {
+              "version": "2.3.0",
+              "dependencies": {
+                "is-promise": {
+                  "version": "2.1.0"
+                }
+              }
+            },
+            "rx": {
+              "version": "4.1.0"
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0"
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "through": {
+              "version": "2.3.8"
+            }
+          }
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.3.0",
+              "dependencies": {
+                "js-tokens": {
+                  "version": "2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "dependencies": {
+            "builtin-modules": {
+              "version": "1.1.1"
+            }
+          }
+        },
+        "is-ci": {
+          "version": "1.0.10",
+          "dependencies": {
+            "ci-info": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "leven": {
+          "version": "2.0.0"
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "dependencies": {
+            "currently-unhandled": {
+              "version": "0.4.1",
+              "dependencies": {
+                "array-find-index": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "signal-exit": {
+              "version": "3.0.2"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.6",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.4.2"
+                },
+                "concat-map": {
+                  "version": "0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8"
+            }
+          }
+        },
+        "node-emoji": {
+          "version": "1.4.3",
+          "dependencies": {
+            "string.prototype.codepointat": {
+              "version": "0.2.0"
+            }
+          }
+        },
+        "node-gyp": {
+          "version": "3.4.0",
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.10",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3"
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.1",
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0"
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3"
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11"
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "npmlog": {
+              "version": "3.1.2",
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0"
+                    },
+                    "readable-stream": {
+                      "version": "2.2.2",
+                      "dependencies": {
+                        "buffer-shims": {
+                          "version": "1.0.0"
+                        },
+                        "core-util-is": {
+                          "version": "1.0.2"
+                        },
+                        "isarray": {
+                          "version": "1.0.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.3"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0"
+                },
+                "gauge": {
+                  "version": "2.6.0",
+                  "dependencies": {
+                    "aproba": {
+                      "version": "1.0.4"
+                    },
+                    "has-color": {
+                      "version": "0.1.7"
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1"
+                    },
+                    "object-assign": {
+                      "version": "4.1.0"
+                    },
+                    "signal-exit": {
+                      "version": "3.0.2"
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0"
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.0"
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "path-array": {
+              "version": "1.0.1",
+              "dependencies": {
+                "array-index": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "3.1.0",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.12",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.12",
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2"
+                }
+              }
+            }
+          }
+        },
+        "object-path": {
+          "version": "0.11.3"
+        },
+        "proper-lockfile": {
+          "version": "1.2.0",
+          "dependencies": {
+            "err-code": {
+              "version": "1.1.1"
+            },
+            "extend": {
+              "version": "3.0.0"
+            },
+            "graceful-fs": {
+              "version": "4.1.11"
+            },
+            "retry": {
+              "version": "0.10.1"
+            }
+          }
+        },
+        "read": {
+          "version": "1.0.7",
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.6"
+            }
+          }
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "dependencies": {
+            "is-finite": {
+              "version": "1.0.2",
+              "dependencies": {
+                "number-is-nan": {
+                  "version": "1.0.1"
+                }
+              }
+            }
+          }
+        },
+        "request": {
+          "version": "2.79.0",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0"
+            },
+            "aws4": {
+              "version": "1.5.0"
+            },
+            "caseless": {
+              "version": "0.11.0"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0"
+            },
+            "forever-agent": {
+              "version": "0.6.1"
+            },
+            "form-data": {
+              "version": "2.1.2",
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "dependencies": {
+                "is-my-json-valid": {
+                  "version": "2.15.0",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.0"
+                    },
+                    "xtend": {
+                      "version": "4.0.1"
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3"
+                },
+                "boom": {
+                  "version": "2.10.1"
+                },
+                "cryptiles": {
+                  "version": "2.0.5"
+                },
+                "sntp": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0"
+                },
+                "jsprim": {
+                  "version": "1.3.1",
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3"
+                    },
+                    "verror": {
+                      "version": "1.3.6"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.10.1",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0"
+                    },
+                    "dashdash": {
+                      "version": "1.14.1"
+                    },
+                    "getpass": {
+                      "version": "0.1.6"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0"
+            },
+            "isstream": {
+              "version": "0.1.2"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1"
+            },
+            "mime-types": {
+              "version": "2.1.13",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.25.0"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2"
+            },
+            "qs": {
+              "version": "6.3.0"
+            },
+            "stringstream": {
+              "version": "0.0.5"
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1"
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.4.3"
+            },
+            "uuid": {
+              "version": "3.0.1"
+            }
+          }
+        },
+        "request-capture-har": {
+          "version": "1.1.4"
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "dependencies": {
+            "glob": {
+              "version": "7.1.1",
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0"
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3"
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "roadrunner": {
+          "version": "1.1.0"
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "dependencies": {
+            "is-utf8": {
+              "version": "0.2.1"
+            }
+          }
+        },
+        "tar": {
+          "version": "2.2.1",
+          "dependencies": {
+            "block-stream": {
+              "version": "0.0.9"
+            },
+            "fstream": {
+              "version": "1.0.10",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.11"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3"
+            }
+          }
+        },
+        "tar-stream": {
+          "version": "1.5.2",
+          "dependencies": {
+            "bl": {
+              "version": "1.1.2",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2"
+                    },
+                    "inherits": {
+                      "version": "2.0.3"
+                    },
+                    "isarray": {
+                      "version": "1.0.0"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "end-of-stream": {
+              "version": "1.1.0",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.3",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.2.2",
+              "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0"
+                },
+                "core-util-is": {
+                  "version": "1.0.2"
+                },
+                "isarray": {
+                  "version": "1.0.0"
+                },
+                "inherits": {
+                  "version": "2.0.3"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7"
+                },
+                "string_decoder": {
+                  "version": "0.10.31"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.1"
+            }
+          }
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2"
+            }
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "dependencies": {
+            "spdx-correct": {
+              "version": "1.0.2",
+              "dependencies": {
+                "spdx-license-ids": {
+                  "version": "1.2.2"
+                }
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "1.0.4"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -217,9 +217,9 @@
       }
     },
     "yarn": {
-      "version": "0.19.0-0",
-      "from": "methyl/yarn",
-      "resolved": "git://github.com/methyl/yarn.git#56e790fab9d218099e17e3170cc4c37d63d5b586",
+      "version": "0.18.1",
+      "from": "yarn@latest",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-0.18.1.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "6.20.0",
@@ -278,9 +278,9 @@
           "resolved": "https://registry.npmjs.org/death/-/death-1.0.0.tgz"
         },
         "debug": {
-          "version": "2.4.4",
+          "version": "2.6.0",
           "from": "debug@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.2",
@@ -371,25 +371,30 @@
                   "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
                   "dependencies": {
                     "concat-stream": {
-                      "version": "1.5.2",
+                      "version": "1.6.0",
                       "from": "concat-stream@>=1.4.7 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@>=2.0.3 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "from": "typedarray@>=0.0.6 <0.0.7",
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
-                          "version": "2.0.6",
-                          "from": "readable-stream@>=2.0.0 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                          "version": "2.2.2",
+                          "from": "readable-stream@>=2.2.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
                           "dependencies": {
+                            "buffer-shims": {
+                              "version": "1.0.0",
+                              "from": "buffer-shims@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                            },
                             "core-util-is": {
                               "version": "1.0.2",
                               "from": "core-util-is@>=1.0.0 <1.1.0",
@@ -458,9 +463,9 @@
               }
             },
             "lodash": {
-              "version": "4.17.2",
+              "version": "4.17.4",
               "from": "lodash@>=4.3.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
             },
             "mute-stream": {
               "version": "0.0.6",
@@ -648,9 +653,9 @@
           }
         },
         "node-emoji": {
-          "version": "1.4.3",
+          "version": "1.5.0",
           "from": "node-emoji@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.5.0.tgz",
           "dependencies": {
             "string.prototype.codepointat": {
               "version": "0.2.0",
@@ -660,9 +665,9 @@
           }
         },
         "node-gyp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "from": "node-gyp@>=3.2.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
           "dependencies": {
             "fstream": {
               "version": "1.0.10",
@@ -735,9 +740,9 @@
               }
             },
             "npmlog": {
-              "version": "3.1.2",
-              "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+              "version": "4.0.2",
+              "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
@@ -799,19 +804,19 @@
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
                 },
                 "gauge": {
-                  "version": "2.6.0",
-                  "from": "gauge@>=2.6.0 <2.7.0",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                  "version": "2.7.2",
+                  "from": "gauge@>=2.7.1 <2.8.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
                   "dependencies": {
                     "aproba": {
                       "version": "1.0.4",
                       "from": "aproba@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
                     },
-                    "has-color": {
-                      "version": "0.1.7",
-                      "from": "has-color@>=0.1.7 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                     },
                     "has-unicode": {
                       "version": "2.0.1",
@@ -895,44 +900,6 @@
                 }
               }
             },
-            "path-array": {
-              "version": "1.0.1",
-              "from": "path-array@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
-              "dependencies": {
-                "array-index": {
-                  "version": "1.0.0",
-                  "from": "array-index@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-                  "dependencies": {
-                    "es6-symbol": {
-                      "version": "3.1.0",
-                      "from": "es6-symbol@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-                      "dependencies": {
-                        "d": {
-                          "version": "0.1.1",
-                          "from": "d@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                        },
-                        "es5-ext": {
-                          "version": "0.10.12",
-                          "from": "es5-ext@>=0.10.11 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-                          "dependencies": {
-                            "es6-iterator": {
-                              "version": "2.0.0",
-                              "from": "es6-iterator@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
             "which": {
               "version": "1.2.12",
               "from": "which@>=1.0.0 <2.0.0",
@@ -985,9 +952,9 @@
           "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
           "dependencies": {
             "mute-stream": {
-              "version": "0.0.6",
+              "version": "0.0.7",
               "from": "mute-stream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz"
             }
           }
         },
@@ -1092,9 +1059,9 @@
                       }
                     },
                     "jsonpointer": {
-                      "version": "4.0.0",
+                      "version": "4.0.1",
                       "from": "jsonpointer@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
@@ -1401,48 +1368,9 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
           "dependencies": {
             "bl": {
-              "version": "1.1.2",
+              "version": "1.2.0",
               "from": "bl@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz"
             },
             "end-of-stream": {
               "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "semver": "^5.0.3",
     "subcommand": "^2.0.3",
     "wreck": "^6.3.0",
-    "yarn": "methyl/yarn"
+    "yarn": "^0.18.1"
   },
   "devDependencies": {
     "code": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "semver": "^5.0.3",
     "subcommand": "^2.0.3",
     "wreck": "^6.3.0",
-    "yarn": "^0.17.10"
+    "yarn": "methyl/yarn"
   },
   "devDependencies": {
     "code": "^1.5.0",
@@ -43,7 +43,7 @@
   "scripts": {
     "lint": "eslint . bin/nsp",
     "setup-offline": "curl -sS https://api.nodesecurity.io/advisories -o advisories.json",
-    "test": "lab -a code -t 100 -I Reflect",
+    "test": "lab -a code -t 100 -I 'Reflect,__core-js_shared__'",
     "nsp": "bin/nsp check",
     "shrinkwrap": "npm shrinkwrap && shrinkydink"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "rc": "^1.1.2",
     "semver": "^5.0.3",
     "subcommand": "^2.0.3",
-    "wreck": "^6.3.0"
+    "wreck": "^6.3.0",
+    "yarn": "^0.17.10"
   },
   "devDependencies": {
     "code": "^1.5.0",

--- a/test/data/yarn.lock
+++ b/test/data/yarn.lock
@@ -1,0 +1,10 @@
+nsp@^2.0.0:
+  version "0.1.1"
+  dependencies:
+    marked "4.0.0"
+
+marked:
+  version "0.3.3"
+
+dummy:
+  version "0.0.0"

--- a/test/unit.js
+++ b/test/unit.js
@@ -113,8 +113,8 @@ describe('check', function () {
   it('Responds correctly to receiving a 200 and findings for yarn', function (done) {
     var options = {
       package: workingOptions.package,
-      yarnlock: Path.resolve(__dirname, './data/yarn.lock'),
-    }
+      yarnlock: Path.resolve(__dirname, './data/yarn.lock')
+    };
 
     Nock('https://api.nodesecurity.io')
       .post('/check')

--- a/test/unit.js
+++ b/test/unit.js
@@ -173,7 +173,24 @@ describe('check', function () {
     };
 
     Check(options, function (err, results) {
+      expect(err).to.not.exist();
+      expect(results).to.exist();
+      done();
+    });
+  });
 
+  it('works offline with yarn.lock', function (done) {
+
+    var options = {
+      package: workingOptions.package,
+      shrinkwrap: Path.resolve(__dirname, './data/not-existing.json'),
+      yarnlock: Path.resolve(__dirname, './data/yarn.lock'),
+      exceptions: exceptions,
+      advisoriesPath: './test/data/advisories.json',
+      offline: true
+    };
+
+    Check(options, function (err, results) {
       expect(err).to.not.exist();
       expect(results).to.exist();
       done();

--- a/test/unit.js
+++ b/test/unit.js
@@ -46,7 +46,7 @@ describe('check', function () {
 
     Check({ package: '../package.json', shrinkwrap: './npm-shrinkwrap.json', offline: true }, function (err) {
 
-      expect(err.message).to.equal('npm-shrinkwrap.json is required for offline mode');
+      expect(err.message).to.equal('npm-shrinkwrap.json / yarn.lock is required for offline mode');
       done();
     });
   });
@@ -103,6 +103,24 @@ describe('check', function () {
       .reply(200, Findings);
 
     Check(workingOptions, function (err, results) {
+
+      expect(err).to.not.exist();
+      expect(results).to.deep.include(Findings);
+      done();
+    });
+  });
+
+  it('Responds correctly to receiving a 200 and findings for yarn', function (done) {
+    var options = {
+      package: workingOptions.package,
+      yarnlock: Path.resolve(__dirname, './data/yarn.lock'),
+    }
+
+    Nock('https://api.nodesecurity.io')
+      .post('/check')
+      .reply(200, Findings);
+
+    Check(options, function (err, results) {
 
       expect(err).to.not.exist();
       expect(results).to.deep.include(Findings);

--- a/usage/check.txt
+++ b/usage/check.txt
@@ -1,6 +1,6 @@
 nsp check
 
-  checks a package.json / npm-shrinkwrap.json for known vulnerabilities against the Node Security API. Non-public and repository based dependencies are currently skipped.
+  checks a package.json / npm-shrinkwrap.json / yarn.lock for known vulnerabilities against the Node Security API. Non-public and repository based dependencies are currently skipped.
 
 Parameters
 
@@ -24,4 +24,3 @@ Parameters
   --warn-only: optional
 
     report errors, but always quit with an exit code of 0
-


### PR DESCRIPTION
This PR adds support for parsing yarn.lock instead of npm-shrinwrap.json.

It was pretty trivial as yarn has module to parse the file to json format, which seems to be pretty much compatible with shrinkwrap.