### PR TITLE
Add ignoreServiceInterruptions flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ nsp has an offline mode which was previously undocumented. We recommend not rely
 First you need to obtain the offline advisories database. Do this by running the `npm run setup-offline` script provided by nsp
 
 Second you need to tell nsp where to find that file. You can do that 3 ways.
+
 1. Put it in the actual nsp module folder and no other configuration is required
 1. Specify it in the .nsprc configuration file `advisoriesPath: "/path/to/advisories.json"`
 1. Specify it from the command line when you call nsp `nsp check --offline --advisoriesPath=/path/to/advisories.json`
@@ -90,6 +91,22 @@ When you call nsp check you will want to use the --offline flag
 A couple of notes
 - Offline mode requires that your project include a npm-shrinkwrap.json file.
 - Because of npm3 flattening reported paths may be incorrect.
+
+## Fail silently when service unavailable
+When integrating nsp into a CI pipeline, it may be desirable to fail silently if the nsp service becomes unavailable, so that builds do not fail due to lack of network.
+
+You can enable this in two ways:
+
+1. Specify it in the .nsprc configuration file:
+
+```js
+{
+    "ignoreServiceInterruptions": true
+}
+```
+
+2. Specify it from the command line when you call nsp: `nsp check --ignoreServiceInterruptions`
+
 
 ## Code Climate Node Security Engine
 

--- a/lib/check.js
+++ b/lib/check.js
@@ -49,7 +49,8 @@ internals.optionSchema = Joi.object({
   shrinkwrap: Joi.alternatives().try(Joi.string(), Joi.object()),
   exceptions: Joi.array().items(Joi.string().regex(internals.exceptionRegex)).default([]),
   advisoriesPath: Joi.string(),
-  proxy: Joi.string()
+  proxy: Joi.string(),
+  ignoreServiceInterruptions: Joi.boolean()
 }).or(['package', 'shrinkwrap']);
 
 /*

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -25,7 +25,15 @@ var onCommand = function (args) {
     var output = args.output(err, result, file);
     var exitCode = (err || (result.length && !args['warn-only'])) ? 1 : 0;
 
-    if (output) {
+    var ignoreServiceInterruptions = args.ignoreServiceInterruption || require('rc')('nsp').ignoreServiceInterruptions;
+
+    if (err && ignoreServiceInterruptions) {
+      exitCode = 0;
+      if (output) {
+        console.error(output);
+      }
+    }
+    else if (output) {
       if (exitCode) {
         console.error(output);
       }
@@ -51,6 +59,11 @@ module.exports = {
     },
     {
       name: 'warn-only',
+      boolean: true,
+      default: false
+    },
+    {
+      name: 'ignoreServiceInterruptions',
       boolean: true,
       default: false
     }

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -1,7 +1,6 @@
 'use strict';
 var usage = require('../../lib/utils/usage.js')('check.txt');
 var Check = require('../check.js');
-var Formatters = require('../formatters');
 var Path = require('path');
 var getFormatter = require('../../lib/index').getFormatter;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 var Formatters = require('./formatters');
 
 var getFormatter = function (name) {
+
   if (Object.keys(Formatters).indexOf(name) !== -1) {
     return Formatters[name];
   }

--- a/usage/check.txt
+++ b/usage/check.txt
@@ -25,3 +25,6 @@ Parameters
 
     report errors, but always quit with an exit code of 0
 
+  --ignoreServiceInterruptions: optional
+
+    fail silently when the Node Security service is unavailable (logs the error but exits with code 0)


### PR DESCRIPTION
To allow nsp to exit with code 0 when there were errors making the request.
Fix for #111 

This implementation does mean the flag will suppress ANY errors - e.g. a 400 if you pass the endpoint bad data. It does still log the error though...