### PR TITLE
Fix nsp CLI crash in the no window (CI) envs

### DIFF
--- a/lib/formatters/default.js
+++ b/lib/formatters/default.js
@@ -18,7 +18,7 @@ module.exports = function (err, data, pkgPath) {
 
   var width = 80;
   if (process.stdout.isTTY) {
-    width = process.stdout.getWindowSize()[0] - 10;
+    width = (process.stdout.getWindowSize()[0] - 10) || 80;
   }
   if (data.length === 0) {
 

--- a/lib/formatters/default.js
+++ b/lib/formatters/default.js
@@ -17,8 +17,12 @@ module.exports = function (err, data, pkgPath) {
   }
 
   var width = 80;
+  var colWidth = 15;
   if (process.stdout.isTTY) {
-    width = (process.stdout.getWindowSize()[0] - 10) || 80;
+    width = process.stdout.getWindowSize()[0] - 10;
+    if (!width || width <= colWidth) {
+      width = 80;
+    }
   }
   if (data.length === 0) {
 
@@ -34,7 +38,7 @@ module.exports = function (err, data, pkgPath) {
 
     var table = new Table({
       head: ['', finding.title],
-      colWidths: [15, width - 15]
+      colWidths: [colWidth, width - colWidth]
     });
 
     table.push(['Name', finding.module]);


### PR DESCRIPTION
This Fixes the following crash:

> nsp check
  ```
/var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/node_modules/cli-table/lib/utils.js:11
  return Array(times + 1).join(str);
         ^
 
RangeError: Invalid array length
    at exports.repeat (/var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/node_modules/cli-table/lib/utils.js:11:10)
    at line (/var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/node_modules/cli-table/lib/index.js:140:11)
    at lineTop (/var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/node_modules/cli-table/lib/index.js:154:13)
    at Table.toString (/var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/node_modules/cli-table/lib/index.js:252:5)
    at /var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/lib/formatters/default.js:48:27
    at Array.forEach (native)
    at Object.module.exports (/var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/lib/formatters/default.js:33:6)
    at /var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/lib/commands/check.js:25:23
    at /var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/lib/check.js:240:7
    at /var/lib/buildkite-agent/builds/ip-10-0-51-163-1/app/node_modules/nsp/node_modules/wreck/lib/index.js:472:20
```