### PR TITLE
Fix issue 166

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To configure the proxy set the proxy key in your `.nsprc` file. This can be put 
 ## Offline Mode
 nsp has an offline mode which was previously undocumented. We recommend not relying on offline support as it may become unsupported in the future as new features are added.
 
-First you need to obtain the offline advisories database. Do this by running the `npm run setup-offline` script provided by nsp
+First you need to obtain the offline advisories database. Do this by running the `npm run setup-offline` script provided by nsp. If you only needs the 100 most recent advisories, run `npm run recent-offline` script instead.
 
 Second you need to tell nsp where to find that file. You can do that 3 ways.
 1. Put it in the actual nsp module folder and no other configuration is required

--- a/merging/.eslintrc
+++ b/merging/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "node": true,
+    "es6": true,
+    "mocha": true
+  }
+}

--- a/merging/download_advisories.js
+++ b/merging/download_advisories.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict';
+
+var FS = require('fs');
+var Wreck = require('wreck');
+
+var MAX_COUNTER = 99;
+var offset = 0;
+var counter = 0;
+
+var getPayload;
+
+var savePayload = function savePayload(err, res, payload) {
+
+  if (err) {
+    throw err;
+  }
+
+  FS.writeFile('advisories_' + offset + '.json', JSON.stringify(payload));
+
+  var total = offset + payload.count;
+  if (payload && payload.count && total < payload.total) {
+    offset += payload.count;
+    if (++counter < MAX_COUNTER) {
+      getPayload();
+    }
+    else {
+      console.log('Reached max of ' + MAX_COUNTER);
+    }
+  }
+  else {
+    console.log('done, total:', total);
+  }
+};
+
+getPayload = function getPayload() {
+
+  var url = 'https://api.nodesecurity.io/advisories?offset=' + offset;
+  console.log('GET ' + url);
+  Wreck.get(url, { json:true }, savePayload);
+};
+
+getPayload();

--- a/merging/merge_advisories.js
+++ b/merging/merge_advisories.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict';
+
+var FS = require('fs');
+var Util = require('util');
+
+// could use match on filename: file.match(/^advisories_(\d+)\.json$/)
+var filesToMerge = FS.readdirSync('.').filter(file => file.indexOf('advisories') === 0 && file.indexOf('.json') > 10 && file !== 'advisories.json');
+console.log(Util.inspect({ filesToMerge }));
+var contents = filesToMerge.map(file => require('./' + file));
+var reducer = (cum, cur) => {
+  cum.results = cum.results.concat(cur.results);
+  cum.total = Math.max(cum.total, cur.total);
+  cum.offset = Math.min(cum.offset, cur.offset);
+  cum.count += cur.count || 0;
+  return cum;
+};
+var initial = { total:0, count:0, offset:Infinity, results: [] };
+var merged = contents.reduce(reducer, initial);
+
+var resultsTotal = merged.results.length;
+
+if (!contents.every( cont => cont.total === merged.total )) {
+  throw new Error('Total changed while downloading advisories! Not all equal to ' + merged.total);
+}
+
+var ids = merged.results.map(cont => cont.id).sort((a,b) => b - a);
+var nonUnique = ids.filter( (id, num, ra) => id === ra[num + 1] );
+
+if (nonUnique.length) {
+  throw new Error(nonUnique.length +
+    ' Advisory ID\'s are not unique: ' +
+    ' (ids in ' + nonUnique[nonUnique.length - 1] + '..' + nonUnique[0] + ')'
+  );
+}
+
+if (merged.total !== resultsTotal) {
+  throw new Error('Not all advisory results downloaded, expected ' + merged.total + ' but got ' + resultsTotal);
+}
+
+FS.writeFileSync('../advisories.json', JSON.stringify(merged), 'utf-8');
+
+console.log('Merged to ../advisories.json');

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "scripts": {
     "lint": "eslint . bin/nsp",
-    "setup-offline": "curl -sS https://api.nodesecurity.io/advisories -o advisories.json",
+    "recent-offline": "curl -sS https://api.nodesecurity.io/advisories -o advisories.json",
+    "setup-offline": "cd merging/ && node download_advisories.js && node merge_advisories.js",
     "test": "lab -a code -t 100 -I Reflect",
     "nsp": "bin/nsp check",
     "shrinkwrap": "npm shrinkwrap && shrinkydink"


### PR DESCRIPTION
Fix for issue #166 so it can download up to 99*100 advisories. Would be nice if api.nodesecurity.io did not have max limit of 100 advisories per request.

Does not have any new dependencies so should not require a new `npm shrinkwrap`.
Can re-write in es5 style instead of es6 if required.
