### PR TITLE
nsp check --output json returns non-json if directory is missing package.json

### DIFF
--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -3,7 +3,7 @@
 module.exports = function (err, data, pkgPath) {
 
   if (err) {
-    return 'Debug output: ' + JSON.stringify(Buffer.isBuffer(data) ? data.toString() : data) + '\n' + JSON.stringify(err);
+    return JSON.stringify({ 'Error': err.message, 'Debug output': (Buffer.isBuffer(data) ? data.toString() : (data === undefined ? 'undefined' : data)) });
   }
 
   return JSON.stringify(data, null, 2);


### PR DESCRIPTION
Fix for Issue #140 

When running `nsp check -o json` and there is no `package.json` in the folder:

New output:
```
{"Error":"Cannot find module '/code/package.json'","Debug output":"undefined"}
```

Old output:
```
Debug output: undefined
{"code":"MODULE_NOT_FOUND"}
```

I noticed that `JSON.stringify` trims the actual error message from the error trace making it inconsistent with other types of output. I.e. default one:
```
(+) Error: Cannot find module '/code/package.json'
```
In the proposed version, the output follows the same rule, and then the debug information is added as previously but now it is actually the part of the JSON output object.