### PR TITLE
Support yarn.lock

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,5 @@ pipeline:
     secrets: [ slack_webhook ]
 matrix:
   NODE_VERSION:
-    - 0.10
-    - 0.12
     - 4
     - 5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# nsp [![Build Status](https://drone.andyet.com/api/badges/nodesecurity/nsp/status.svg)](https://drone.andyet.com/nodesecurity/nsp)
+# nsp 
+[![Build Status](https://build.andyet.com/api/badges/nodesecurity/nsp/status.svg)](https://build.andyet.com/nodesecurity/nsp)
 
 ## About Node Security
 
@@ -138,6 +139,10 @@ codeclimate analyze --dev
 
 ## Suggesting Changes to Advisories
 Should you come across data in an advisory that you feel is wrong or is a false positive please let us know at report@nodesecurity.io. We endeavor to make this process better in the future, however this is the best place to resolve these issues at the present.
+
+## Continuous Security Monitoring
+Want continuous security monitoring of your projects? Check out [nodesecurity.io](https://nodesecurity.io).
+
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ Second you need to tell nsp where to find that file. You can do that 3 ways.
 When you call nsp check you will want to use the --offline flag
 
 A couple of notes
-- Offline mode requires that your project include a npm-shrinkwrap.json file.
+- Offline mode requires that your project include a npm-shrinkwrap.json or yarn.lock file.
 - Because of npm3 flattening reported paths may be incorrect.
 
 ## Code Climate Node Security Engine
 
 `codeclimate-nodesecurity` is a Code Climate engine that wraps the Node Security CLI. You can run it on your command line using the Code Climate CLI, or Code Climate's <a href="http://codeclimate.com">hosted analysis platform</a>.
 
-Note that this engine *only* works if your code has a `npm-shrinkwrap.json` file committed.
+Note that this engine *only* works if your code has a `npm-shrinkwrap.json` or `yarn.lock` file committed.
 
 ### Testing
 

--- a/lib/check.js
+++ b/lib/check.js
@@ -47,16 +47,18 @@ internals.exceptionRegex = /^https\:\/\/nodesecurity\.io\/advisories\/([0-9]+)$/
 internals.optionSchema = Joi.object({
   package: Joi.alternatives().try(Joi.string(), Joi.object()),
   shrinkwrap: Joi.alternatives().try(Joi.string(), Joi.object()),
+  packagelock: Joi.alternatives().try(Joi.string(), Joi.object()),
   exceptions: Joi.array().items(Joi.string().regex(internals.exceptionRegex)).default([]),
   advisoriesPath: Joi.string(),
   proxy: Joi.string()
-}).or(['package', 'shrinkwrap']);
+});
 
 /*
-options should be an object that contains one or more of the keys package, shrinkwrap, offline, advisoriesPath
+options should be an object that contains one or more of the keys package, shrinkwrap, offline, packagelock, advisoriesPath
   {
     package: '/path/to/package.json',
     shrinkwrap: '/path/to/npm-shrinkwrap.json',
+    packagelock: '/path/to/package-lock.json',
     offline: false,
     advisoriesPath: undefined
   }
@@ -80,6 +82,7 @@ module.exports = function (options, callback) {
   var wreck = Wreck.defaults(Conf.api);
 
   var shrinkwrap;
+  var packagelock;
   var offline = options.offline;
   delete options.offline;
 
@@ -122,6 +125,23 @@ module.exports = function (options, callback) {
   else {
     shrinkwrap = JSON.stringify(options.shrinkwrap, null, 2);
   }
+
+  // If there is a shrinkwrap it will be used, ignore package-lock in this case.
+  if (!shrinkwrap && typeof options.packagelock === 'string') {
+
+    try {
+      packagelock = Fs.readFileSync(require.resolve(options.packagelock), 'utf8');
+      options.packagelock = require(options.packagelock);
+    }
+    catch (e) {
+      delete options.packagelock;
+    }
+  }
+  else {
+    delete options.packagelock;
+    packagelock = JSON.stringify(options.packagelock, null, 2);
+  }
+
 
   if (offline) {
     var advisories;

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,7 +9,7 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
-var parseYarnLock = require('yarn/lib-legacy/lockfile/parse').default;
+var lockfile = require('@yarnpkg/lockfile');
 
 var Conf = require('rc')('nsp', {
   api: {
@@ -134,7 +134,7 @@ module.exports = function (options, callback) {
   if (!options.shrinkwrap) {
     if (options.yarnlock) {
       var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
-      options.shrinkwrap = { dependencies: parseYarnLock(yarnlock) };
+      options.shrinkwrap = { dependencies: lockfile.parse(yarnlock) };
       shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
     }
   }

--- a/lib/check.js
+++ b/lib/check.js
@@ -136,7 +136,11 @@ module.exports = function (options, callback) {
   if (!options.shrinkwrap) {
     if (options.yarnlock) {
       var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
-      options.shrinkwrap = Yarn.parse(yarnlock);
+      try {
+        options.shrinkwrap = Yarn.parse(yarnlock, options.package);
+      } catch (err) {
+        return callback(err);
+      }
       shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
     }
   }
@@ -260,9 +264,6 @@ module.exports = function (options, callback) {
   else {
     if (!options.package) {
       return callback(new Error('package.json is required'));
-    }
-    if (options.shrinkwrap && !options.shrinkwrap.name) {
-      options.shrinkwrap.name = options.package.name;
     }
     delete options.yarnlock;
     wreck.post('/check', { payload: JSON.stringify(options) }, function (err, res, payload) {

--- a/lib/check.js
+++ b/lib/check.js
@@ -138,7 +138,8 @@ module.exports = function (options, callback) {
       var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
       try {
         options.shrinkwrap = Yarn.parse(yarnlock, options.package);
-      } catch (err) {
+      }
+      catch (err) {
         return callback(err);
       }
       shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,19 +9,23 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
-var lockfile = require('@yarnpkg/lockfile');
+var Lockfile = require('@yarnpkg/lockfile');
 
-function transformYarn(result) {
-  function processPackages(object) {
+var internals = {};
+
+internals.transformYarn = function transformYarn(result) {
+
+  internals.processPackages = function processPackages(object) {
+
     Object.keys(object).forEach(function (packageAtVersion) {
       // Nested dependencies must be { version: "x" } instead of "x"
       if (typeof object[packageAtVersion].dependencies === 'object') {
-        deepenDependencies(object[packageAtVersion].dependencies);
+        internals.deepenDependencies(object[packageAtVersion].dependencies);
       }
 
       // Strip version from 'package@^6.1.2'
       // Handle package scopes like '@types/nsp@1.2.0'
-      var versionAt = packageAtVersion.indexOf("@", 1);
+      var versionAt = packageAtVersion.indexOf('@', 1);
       if (versionAt >= 1) {
         var packageName = packageAtVersion.substr(0, versionAt);
         if (typeof object[packageName] === 'undefined') {
@@ -31,19 +35,22 @@ function transformYarn(result) {
       }
     });
     return object;
-  }
-  function deepenDependencies(deps) {
+  };
+
+  internals.deepenDependencies = function deepenDependencies(deps) {
+
     Object.keys(deps).forEach(function (dep) {
+
       if (typeof deps[dep] === 'string') {
         deps[dep] = { version: deps[dep] };
       }
     });
-  }
+  };
 
-  processPackages(result.object);
-  deepenDependencies(result.object);
+  internals.processPackages(result.object);
+  internals.deepenDependencies(result.object);
   return { dependencies: result.object };
-}
+};
 
 var Conf = require('rc')('nsp', {
   api: {
@@ -55,7 +62,6 @@ var Conf = require('rc')('nsp', {
   }
 }, []);
 
-var internals = {};
 internals.findLines = function (shrinkwrap, module, version) {
 
   var modRE = new RegExp('\\s*\"' + module + '\":\\s*\\{\\s*([^\\}]*)\\}', 'gm');
@@ -78,6 +84,7 @@ internals.findLines = function (shrinkwrap, module, version) {
 };
 
 internals.stringifyShrinkwrap = function (shrinkwrap) {
+
   return JSON.stringify(shrinkwrap, null, 2);
 };
 
@@ -168,7 +175,7 @@ module.exports = function (options, callback) {
   if (!options.shrinkwrap) {
     if (options.yarnlock) {
       var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
-      options.shrinkwrap = transformYarn(lockfile.parse(yarnlock));
+      options.shrinkwrap = internals.transformYarn(Lockfile.parse(yarnlock));
       shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
     }
   }

--- a/lib/check.js
+++ b/lib/check.js
@@ -241,6 +241,7 @@ module.exports = function (options, callback) {
     if (options.shrinkwrap && !options.shrinkwrap.name) {
       options.shrinkwrap.name = options.package.name;
     }
+    delete options.yarnlock;
     wreck.post('/check', { payload: JSON.stringify(options) }, function (err, res, payload) {
 
       if (err) {

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,7 +9,7 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
-var parseYarnLock = require('yarn/lib-legacy/lockfile/parse').default;
+var parseYarnLock = require('yarn/lib-es5/lockfile/parse').default;
 
 var Conf = require('rc')('nsp', {
   api: {

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,48 +9,9 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
-var Lockfile = require('@yarnpkg/lockfile');
+var Yarn = require('./utils/yarn');
 
 var internals = {};
-
-internals.transformYarn = function transformYarn(result) {
-
-  internals.processPackages = function processPackages(object) {
-
-    Object.keys(object).forEach(function (packageAtVersion) {
-      // Nested dependencies must be { version: "x" } instead of "x"
-      if (typeof object[packageAtVersion].dependencies === 'object') {
-        internals.deepenDependencies(object[packageAtVersion].dependencies);
-      }
-
-      // Strip version from 'package@^6.1.2'
-      // Handle package scopes like '@types/nsp@1.2.0'
-      var versionAt = packageAtVersion.indexOf('@', 1);
-      if (versionAt >= 1) {
-        var packageName = packageAtVersion.substr(0, versionAt);
-        if (typeof object[packageName] === 'undefined') {
-          object[packageName] = object[packageAtVersion];
-          delete object[packageAtVersion];
-        }
-      }
-    });
-    return object;
-  };
-
-  internals.deepenDependencies = function deepenDependencies(deps) {
-
-    Object.keys(deps).forEach(function (dep) {
-
-      if (typeof deps[dep] === 'string') {
-        deps[dep] = { version: deps[dep] };
-      }
-    });
-  };
-
-  internals.processPackages(result.object);
-  internals.deepenDependencies(result.object);
-  return { dependencies: result.object };
-};
 
 var Conf = require('rc')('nsp', {
   api: {
@@ -175,7 +136,7 @@ module.exports = function (options, callback) {
   if (!options.shrinkwrap) {
     if (options.yarnlock) {
       var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
-      options.shrinkwrap = internals.transformYarn(Lockfile.parse(yarnlock));
+      options.shrinkwrap = Yarn.parse(yarnlock);
       shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
     }
   }

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,7 +9,7 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
-var parseYarnLock = require('yarn/lib-es5/lockfile/parse').default;
+var parseYarnLock = require('yarn/lib-legacy/lockfile/parse').default;
 
 var Conf = require('rc')('nsp', {
   api: {

--- a/lib/check.js
+++ b/lib/check.js
@@ -11,6 +11,40 @@ var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
 var lockfile = require('@yarnpkg/lockfile');
 
+function transformYarn(result) {
+  function processPackages(object) {
+    Object.keys(object).forEach(function (packageAtVersion) {
+      // Nested dependencies must be { version: "x" } instead of "x"
+      if (typeof object[packageAtVersion].dependencies === 'object') {
+        deepenDependencies(object[packageAtVersion].dependencies);
+      }
+
+      // Strip version from 'package@^6.1.2'
+      // Handle package scopes like '@types/nsp@1.2.0'
+      var versionAt = packageAtVersion.indexOf("@", 1);
+      if (versionAt >= 1) {
+        var packageName = packageAtVersion.substr(0, versionAt);
+        if (typeof object[packageName] === 'undefined') {
+          object[packageName] = object[packageAtVersion];
+          delete object[packageAtVersion];
+        }
+      }
+    });
+    return object;
+  }
+  function deepenDependencies(deps) {
+    Object.keys(deps).forEach(function (dep) {
+      if (typeof deps[dep] === 'string') {
+        deps[dep] = { version: deps[dep] };
+      }
+    });
+  }
+
+  processPackages(result.object);
+  deepenDependencies(result.object);
+  return { dependencies: result.object };
+}
+
 var Conf = require('rc')('nsp', {
   api: {
     baseUrl: 'https://api.nodesecurity.io',
@@ -134,7 +168,7 @@ module.exports = function (options, callback) {
   if (!options.shrinkwrap) {
     if (options.yarnlock) {
       var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
-      options.shrinkwrap = { dependencies: lockfile.parse(yarnlock) };
+      options.shrinkwrap = transformYarn(lockfile.parse(yarnlock));
       shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
     }
   }

--- a/lib/check.js
+++ b/lib/check.js
@@ -127,7 +127,6 @@ module.exports = function (options, callback) {
   else {
     shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
   }
-
   if (!options.shrinkwrap) {
     if (options.yarnlock) {
       var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
@@ -139,7 +138,7 @@ module.exports = function (options, callback) {
   if (offline) {
     var advisories;
     if (!options.shrinkwrap) {
-      return callback(new Error('npm-shrinkwrap.json is required for offline mode'));
+      return callback(new Error('npm-shrinkwrap.json / yarn.lock is required for offline mode'));
     }
     try {
       if (advisoriesPath) {
@@ -238,6 +237,9 @@ module.exports = function (options, callback) {
   else {
     if (!options.package) {
       return callback(new Error('package.json is required'));
+    }
+    if (options.shrinkwrap && !options.shrinkwrap.name) {
+      options.shrinkwrap.name = options.package.name;
     }
     wreck.post('/check', { payload: JSON.stringify(options) }, function (err, res, payload) {
 

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,6 +9,7 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
+var parseYarnLock = require('yarn/lib/lockfile/parse').default;
 
 var Conf = require('rc')('nsp', {
   api: {
@@ -42,11 +43,16 @@ internals.findLines = function (shrinkwrap, module, version) {
   };
 };
 
+internals.stringifyShrinkwrap = function (shrinkwrap) {
+  return JSON.stringify(shrinkwrap, null, 2);
+};
+
 internals.exceptionRegex = /^https\:\/\/nodesecurity\.io\/advisories\/([0-9]+)$/;
 
 internals.optionSchema = Joi.object({
   package: Joi.alternatives().try(Joi.string(), Joi.object()),
   shrinkwrap: Joi.alternatives().try(Joi.string(), Joi.object()),
+  yarnlock: Joi.string(),
   exceptions: Joi.array().items(Joi.string().regex(internals.exceptionRegex)).default([]),
   advisoriesPath: Joi.string(),
   proxy: Joi.string()
@@ -119,12 +125,19 @@ module.exports = function (options, callback) {
     }
   }
   else {
-    shrinkwrap = JSON.stringify(options.shrinkwrap, null, 2);
+    shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
+  }
+
+  if (!options.shrinkwrap) {
+    if (options.yarnlock) {
+      var yarnlock = Fs.readFileSync(require.resolve(options.yarnlock), 'utf8');
+      options.shrinkwrap = { dependencies: parseYarnLock(yarnlock) };
+      shrinkwrap = internals.stringifyShrinkwrap(options.shrinkwrap);
+    }
   }
 
   if (offline) {
     var advisories;
-
     if (!options.shrinkwrap) {
       return callback(new Error('npm-shrinkwrap.json is required for offline mode'));
     }

--- a/lib/check.js
+++ b/lib/check.js
@@ -9,7 +9,7 @@ var Path = require('path');
 var Wreck = require('wreck');
 var PathIsAbsolute = require('path-is-absolute');
 var SanitizePackage = require('./utils/sanitizePackage');
-var parseYarnLock = require('yarn/lib/lockfile/parse').default;
+var parseYarnLock = require('yarn/lib-legacy/lockfile/parse').default;
 
 var Conf = require('rc')('nsp', {
   api: {

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -17,8 +17,9 @@ var onCommand = function (args) {
 
   var pkgPath = Path.join(process.cwd(), 'package.json');
   var shrinkwrapPath = Path.join(process.cwd(), 'npm-shrinkwrap.json');
+  var packageLockPath = Path.join(process.cwd(), 'package-lock.json');
 
-  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, offline: args.offline, advisoriesPath: args.advisoriesPath }, function (err, result) {
+  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, packagelock: packageLockPath, offline: args.offline, advisoriesPath: args.advisoriesPath }, function (err, result) {
 
     var file = args.offline ? shrinkwrapPath : pkgPath;
     var output = args.output(err, result, file);

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -18,8 +18,9 @@ var onCommand = function (args) {
 
   var pkgPath = Path.join(process.cwd(), 'package.json');
   var shrinkwrapPath = Path.join(process.cwd(), 'npm-shrinkwrap.json');
+  var yarnLockPath = Path.join(process.cwd(), 'yarn.lock');
 
-  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, offline: args.offline, advisoriesPath: args.advisoriesPath }, function (err, result) {
+  Check({ package: pkgPath, shrinkwrap: shrinkwrapPath, yarnlock: yarnLockPath, offline: args.offline, advisoriesPath: args.advisoriesPath }, function (err, result) {
 
     var file = args.offline ? shrinkwrapPath : pkgPath;
     var output = args.output(err, result, file);

--- a/lib/utils/yarn.js
+++ b/lib/utils/yarn.js
@@ -9,7 +9,7 @@ module.exports = {
 
     var dependencies = Object.keys(packageJson).reduce(function (acc, key) {
 
-      return  typeof packageJson[key] === 'object' ?
+      return  typeof packageJson[key] === 'object' && key !== "engines" ?
         Object.assign(acc, packageJson[key]) :
         acc;
     }, {});
@@ -17,22 +17,32 @@ module.exports = {
     return {
       name: packageJson.name,
       version: packageJson.version,
-      dependencies: module.exports.buildTree(dependencies, result.object)
+      dependencies: module.exports.buildTree(dependencies, result.object, [packageJson.name])
     };
   },
-  buildTree: function (dependencies, yarn) {
+  buildTree: function (dependencies, yarn, path) {
 
     return Object.keys(dependencies).reduce(function (acc, packageName) {
 
       var version = dependencies[packageName];
-      var info = yarn[packageName + '@' + version];
+      var packageNV = packageName + '@' + version;
+      var info = yarn[packageNV];
+
       if (!info) {
-        throw new Error('yarn.lock is outdated: it does not contain the package ' + packageName + '@' + version);
+        throw new Error('yarn.lock is outdated: it does not contain the package ' + packageNV);
       }
+
+      if (path.indexOf(packageNV) >= 0) {
+        // Prevent looping over circular dependencies (for example babel-register@^6.26.0 > babel-core@^6.26.0 > babel-register@^6.26.0)
+        return acc;
+      }
+      var currentPath = path.slice(0);
+      currentPath.push(packageNV);
+
       acc[packageName] = {
-        'version': version,
+        'version': info.version,
         'dependencies': typeof info.dependencies === 'object' ?
-          module.exports.buildTree(info.dependencies, yarn) :
+          module.exports.buildTree(info.dependencies, yarn, currentPath) :
           undefined
       };
       return acc;

--- a/lib/utils/yarn.js
+++ b/lib/utils/yarn.js
@@ -3,36 +3,35 @@
 var Lockfile = require('@yarnpkg/lockfile');
 
 module.exports = {
-	parse: function yarnParse(contents) {
+	parse: function yarnParse(contents, packageJson) {
 		var result = Lockfile.parse(contents);
-		module.exports.processPackages(result.object);
-		module.exports.deepenDependencies(result.object);
-		return result.object;
-	},
-	deepenDependencies: function deepenDependencies(deps) {
-		Object.keys(deps).forEach(function (dep) {
-			if (typeof deps[dep] === 'string') {
-				deps[dep] = { version: deps[dep] };
-			}
-		});
-	},
-	processPackages: function processPackages(object) {
-		Object.keys(object).forEach(function (packageAtVersion) {
-			// Nested dependencies must be { version: "x" } instead of "x"
-			if (typeof object[packageAtVersion].dependencies === 'object') {
-				module.exports.deepenDependencies(object[packageAtVersion].dependencies);
-			}
 
-			// Strip version from 'package@^6.1.2'
-			// Handle package scopes like '@types/nsp@1.2.0'
-			var versionAt = packageAtVersion.indexOf('@', 1);
-			if (versionAt >= 1) {
-				var packageName = packageAtVersion.substr(0, versionAt);
-				if (typeof object[packageName] === 'undefined') {
-					object[packageName] = object[packageAtVersion];
-					delete object[packageAtVersion];
-				}
+		var dependencies = Object.keys(packageJson).reduce(
+			(acc, key) => typeof packageJson[key] === 'object' ?
+				Object.assign(acc, packageJson[key]) :
+				acc,
+			{});
+
+		return {
+			name: packageJson.name,
+			version: packageJson.version,
+			dependencies: module.exports.buildTree(dependencies, result.object),
+		};
+	},
+	buildTree: function (dependencies, yarn) {
+		return Object.keys(dependencies).reduce((acc, packageName) => {
+			var version = dependencies[packageName];
+			var info = yarn[packageName+"@"+version];
+			if (!info) {
+				throw new Error("yarn.lock is outdated: it does not contain the package " + packageName + "@" + version);
 			}
-		});
+			acc[packageName] = {
+				"version": version,
+				"dependencies": typeof info.dependencies === 'object' ? 
+					module.exports.buildTree(info.dependencies, yarn) : 
+					undefined
+			}
+			return acc;
+		}, {});
 	},
 };

--- a/lib/utils/yarn.js
+++ b/lib/utils/yarn.js
@@ -9,7 +9,7 @@ module.exports = {
 
     var dependencies = Object.keys(packageJson).reduce(function (acc, key) {
 
-      return  typeof packageJson[key] === 'object' && key !== "engines" ?
+      return  typeof packageJson[key] === 'object' && key !== 'engines' ?
         Object.assign(acc, packageJson[key]) :
         acc;
     }, {});

--- a/lib/utils/yarn.js
+++ b/lib/utils/yarn.js
@@ -3,35 +3,39 @@
 var Lockfile = require('@yarnpkg/lockfile');
 
 module.exports = {
-	parse: function yarnParse(contents, packageJson) {
-		var result = Lockfile.parse(contents);
+  parse: function yarnParse(contents, packageJson) {
 
-		var dependencies = Object.keys(packageJson).reduce(
-			(acc, key) => typeof packageJson[key] === 'object' ?
-				Object.assign(acc, packageJson[key]) :
-				acc,
-			{});
+    var result = Lockfile.parse(contents);
 
-		return {
-			name: packageJson.name,
-			version: packageJson.version,
-			dependencies: module.exports.buildTree(dependencies, result.object),
-		};
-	},
-	buildTree: function (dependencies, yarn) {
-		return Object.keys(dependencies).reduce((acc, packageName) => {
-			var version = dependencies[packageName];
-			var info = yarn[packageName+"@"+version];
-			if (!info) {
-				throw new Error("yarn.lock is outdated: it does not contain the package " + packageName + "@" + version);
-			}
-			acc[packageName] = {
-				"version": version,
-				"dependencies": typeof info.dependencies === 'object' ? 
-					module.exports.buildTree(info.dependencies, yarn) : 
-					undefined
-			}
-			return acc;
-		}, {});
-	},
+    var dependencies = Object.keys(packageJson).reduce(function (acc, key) {
+
+      return  typeof packageJson[key] === 'object' ?
+        Object.assign(acc, packageJson[key]) :
+        acc;
+    }, {});
+
+    return {
+      name: packageJson.name,
+      version: packageJson.version,
+      dependencies: module.exports.buildTree(dependencies, result.object)
+    };
+  },
+  buildTree: function (dependencies, yarn) {
+
+    return Object.keys(dependencies).reduce(function (acc, packageName) {
+
+      var version = dependencies[packageName];
+      var info = yarn[packageName + '@' + version];
+      if (!info) {
+        throw new Error('yarn.lock is outdated: it does not contain the package ' + packageName + '@' + version);
+      }
+      acc[packageName] = {
+        'version': version,
+        'dependencies': typeof info.dependencies === 'object' ?
+          module.exports.buildTree(info.dependencies, yarn) :
+          undefined
+      };
+      return acc;
+    }, {});
+  }
 };

--- a/lib/utils/yarn.js
+++ b/lib/utils/yarn.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var Lockfile = require('@yarnpkg/lockfile');
+
+module.exports = {
+	parse: function yarnParse(contents) {
+		var result = Lockfile.parse(contents);
+		module.exports.processPackages(result.object);
+		module.exports.deepenDependencies(result.object);
+		return result.object;
+	},
+	deepenDependencies: function deepenDependencies(deps) {
+		Object.keys(deps).forEach(function (dep) {
+			if (typeof deps[dep] === 'string') {
+				deps[dep] = { version: deps[dep] };
+			}
+		});
+	},
+	processPackages: function processPackages(object) {
+		Object.keys(object).forEach(function (packageAtVersion) {
+			// Nested dependencies must be { version: "x" } instead of "x"
+			if (typeof object[packageAtVersion].dependencies === 'object') {
+				module.exports.deepenDependencies(object[packageAtVersion].dependencies);
+			}
+
+			// Strip version from 'package@^6.1.2'
+			// Handle package scopes like '@types/nsp@1.2.0'
+			var versionAt = packageAtVersion.indexOf('@', 1);
+			if (versionAt >= 1) {
+				var packageName = packageAtVersion.substr(0, versionAt);
+				if (typeof object[packageName] === 'undefined') {
+					object[packageName] = object[packageAtVersion];
+					delete object[packageAtVersion];
+				}
+			}
+		});
+	},
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,281 +4,437 @@
   "dependencies": {
     "chalk": {
       "version": "1.1.3",
+      "from": "chalk@1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.1"
+          "version": "2.2.1",
+          "from": "ansi-styles@2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
         },
         "escape-string-regexp": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "from": "escape-string-regexp@1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
+          "from": "has-ansi@2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "from": "ansi-regex@2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             }
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "from": "strip-ansi@3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "from": "ansi-regex@2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             }
           }
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "supports-color@2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "cli-table": {
       "version": "0.3.1",
+      "from": "cli-table@0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "dependencies": {
         "colors": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "from": "colors@1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
         }
       }
     },
     "https-proxy-agent": {
       "version": "1.0.0",
+      "from": "https-proxy-agent@1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "dependencies": {
         "agent-base": {
           "version": "2.0.1",
+          "from": "agent-base@2.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
           "dependencies": {
             "semver": {
-              "version": "5.0.3"
+              "version": "5.0.3",
+              "from": "semver@5.0.3",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
             }
           }
         },
         "debug": {
           "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
-              "version": "0.7.1"
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "extend": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "from": "extend@3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         }
       }
     },
     "joi": {
       "version": "6.10.1",
+      "from": "joi@6.10.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.16.3"
+          "version": "2.16.3",
+          "from": "hoek@2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "topo": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "from": "topo@1.1.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
         },
         "isemail": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "from": "isemail@1.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
         },
         "moment": {
-          "version": "2.12.0"
+          "version": "2.12.0",
+          "from": "moment@2.12.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
         }
       }
     },
     "nodesecurity-npm-utils": {
-      "version": "5.0.0"
+      "version": "5.0.0",
+      "from": "nodesecurity-npm-utils@5.0.0",
+      "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz"
     },
     "path-is-absolute": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "path-is-absolute@1.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "rc": {
       "version": "1.1.6",
+      "from": "rc@1.1.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
       "dependencies": {
         "deep-extend": {
-          "version": "0.4.1"
+          "version": "0.4.1",
+          "from": "deep-extend@0.4.1",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
         },
         "ini": {
-          "version": "1.3.4"
+          "version": "1.3.4",
+          "from": "ini@1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
         "minimist": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "from": "minimist@1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "strip-json-comments": {
-          "version": "1.0.4"
+          "version": "1.0.4",
+          "from": "strip-json-comments@1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         }
       }
     },
     "semver": {
-      "version": "5.1.0"
+      "version": "5.1.0",
+      "from": "semver@5.1.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
     "subcommand": {
       "version": "2.0.3",
+      "from": "subcommand@2.0.3",
+      "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
       "dependencies": {
         "cliclopts": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "from": "cliclopts@1.1.1",
+          "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz"
         },
         "debug": {
           "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
-              "version": "0.7.1"
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "minimist": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "xtend": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "from": "xtend@4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "wreck": {
       "version": "6.3.0",
+      "from": "wreck@6.3.0",
+      "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.16.3"
+          "version": "2.16.3",
+          "from": "hoek@2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "boom": {
-          "version": "2.10.1"
+          "version": "2.10.1",
+          "from": "boom@2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         }
       }
     },
     "yarn": {
-      "version": "0.17.10",
+      "version": "0.19.0-0",
+      "from": "methyl/yarn",
+      "resolved": "git://github.com/methyl/yarn.git#56e790fab9d218099e17e3170cc4c37d63d5b586",
       "dependencies": {
         "babel-runtime": {
           "version": "6.20.0",
+          "from": "babel-runtime@>=6.0.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
           "dependencies": {
             "core-js": {
-              "version": "2.4.1"
+              "version": "2.4.1",
+              "from": "core-js@>=2.4.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
             },
             "regenerator-runtime": {
-              "version": "0.10.1"
+              "version": "0.10.1",
+              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
             }
           }
         },
         "bytes": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "from": "bytes@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
         },
         "camelcase": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
         },
         "cmd-shim": {
           "version": "2.0.2",
+          "from": "cmd-shim@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
           "dependencies": {
             "graceful-fs": {
-              "version": "4.1.11"
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             }
           }
         },
         "commander": {
           "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dependencies": {
             "graceful-readlink": {
-              "version": "1.0.1"
+              "version": "1.0.1",
+              "from": "graceful-readlink@>=1.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "death": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "death@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/death/-/death-1.0.0.tgz"
         },
         "debug": {
           "version": "2.4.4",
+          "from": "debug@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.4.4.tgz",
           "dependencies": {
             "ms": {
-              "version": "0.7.2"
+              "version": "0.7.2",
+              "from": "ms@0.7.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
             }
           }
         },
         "defaults": {
           "version": "1.0.3",
+          "from": "defaults@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
           "dependencies": {
             "clone": {
-              "version": "1.0.2"
+              "version": "1.0.2",
+              "from": "clone@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
             }
           }
         },
         "detect-indent": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "from": "detect-indent@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
         },
         "diff": {
-          "version": "2.2.3"
+          "version": "2.2.3",
+          "from": "diff@>=2.2.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
         },
         "ini": {
-          "version": "1.3.4"
+          "version": "1.3.4",
+          "from": "ini@>=1.3.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
         "inquirer": {
           "version": "1.2.3",
+          "from": "inquirer@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
           "dependencies": {
             "ansi-escapes": {
-              "version": "1.4.0"
+              "version": "1.4.0",
+              "from": "ansi-escapes@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
             },
             "cli-cursor": {
               "version": "1.0.2",
+              "from": "cli-cursor@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
               "dependencies": {
                 "restore-cursor": {
                   "version": "1.0.1",
+                  "from": "restore-cursor@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                   "dependencies": {
                     "exit-hook": {
-                      "version": "1.1.1"
+                      "version": "1.1.1",
+                      "from": "exit-hook@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
                     },
                     "onetime": {
-                      "version": "1.1.0"
+                      "version": "1.1.0",
+                      "from": "onetime@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
                     }
                   }
                 }
               }
             },
             "cli-width": {
-              "version": "2.1.0"
+              "version": "2.1.0",
+              "from": "cli-width@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
             },
             "external-editor": {
               "version": "1.1.1",
+              "from": "external-editor@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
               "dependencies": {
                 "extend": {
-                  "version": "3.0.0"
+                  "version": "3.0.0",
+                  "from": "extend@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "spawn-sync": {
                   "version": "1.0.15",
+                  "from": "spawn-sync@>=1.0.15 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.5.2",
+                      "from": "concat-stream@>=1.4.7 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
                       "dependencies": {
                         "inherits": {
-                          "version": "2.0.3"
+                          "version": "2.0.3",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "typedarray": {
-                          "version": "0.0.6"
+                          "version": "0.0.6",
+                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "2.0.6",
+                          "from": "readable-stream@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.2"
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
-                              "version": "1.0.0"
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             },
                             "process-nextick-args": {
-                              "version": "1.0.7"
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                             },
                             "string_decoder": {
-                              "version": "0.10.31"
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "util-deprecate": {
-                              "version": "1.0.2"
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
                         }
                       }
                     },
                     "os-shim": {
-                      "version": "0.1.3"
+                      "version": "0.1.3",
+                      "from": "os-shim@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
                     }
                   }
                 },
                 "tmp": {
                   "version": "0.0.29",
+                  "from": "tmp@>=0.0.29 <0.0.30",
+                  "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
                   "dependencies": {
                     "os-tmpdir": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "os-tmpdir@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
                     }
                   }
                 }
@@ -286,51 +442,79 @@
             },
             "figures": {
               "version": "1.7.0",
+              "from": "figures@>=1.3.5 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
               "dependencies": {
                 "escape-string-regexp": {
-                  "version": "1.0.5"
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "object-assign": {
-                  "version": "4.1.0"
+                  "version": "4.1.0",
+                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 }
               }
             },
             "lodash": {
-              "version": "4.17.2"
+              "version": "4.17.2",
+              "from": "lodash@>=4.3.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
             },
             "mute-stream": {
-              "version": "0.0.6"
+              "version": "0.0.6",
+              "from": "mute-stream@0.0.6",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
             },
             "pinkie-promise": {
               "version": "2.0.1",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "dependencies": {
                 "pinkie": {
-                  "version": "2.0.4"
+                  "version": "2.0.4",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
             },
             "run-async": {
               "version": "2.3.0",
+              "from": "run-async@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
               "dependencies": {
                 "is-promise": {
-                  "version": "2.1.0"
+                  "version": "2.1.0",
+                  "from": "is-promise@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
                 }
               }
             },
             "rx": {
-              "version": "4.1.0"
+              "version": "4.1.0",
+              "from": "rx@>=4.1.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
             },
             "string-width": {
               "version": "1.0.2",
+              "from": "string-width@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "dependencies": {
                 "code-point-at": {
-                  "version": "1.1.0"
+                  "version": "1.1.0",
+                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
+                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.1"
+                      "version": "1.0.1",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     }
                   }
                 }
@@ -338,25 +522,37 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "through": {
-              "version": "2.3.8"
+              "version": "2.3.8",
+              "from": "through@>=2.3.6 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "invariant": {
           "version": "2.2.2",
+          "from": "invariant@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
           "dependencies": {
             "loose-envify": {
               "version": "1.3.0",
+              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
               "dependencies": {
                 "js-tokens": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "from": "js-tokens@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
                 }
               }
             }
@@ -364,50 +560,76 @@
         },
         "is-builtin-module": {
           "version": "1.0.0",
+          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "dependencies": {
             "builtin-modules": {
-              "version": "1.1.1"
+              "version": "1.1.1",
+              "from": "builtin-modules@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
             }
           }
         },
         "is-ci": {
           "version": "1.0.10",
+          "from": "is-ci@>=1.0.10 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
           "dependencies": {
             "ci-info": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "from": "ci-info@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz"
             }
           }
         },
         "leven": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "leven@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.0.0.tgz"
         },
         "loud-rejection": {
           "version": "1.6.0",
+          "from": "loud-rejection@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
           "dependencies": {
             "currently-unhandled": {
               "version": "0.4.1",
+              "from": "currently-unhandled@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
               "dependencies": {
                 "array-find-index": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "array-find-index@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
                 }
               }
             },
             "signal-exit": {
-              "version": "3.0.2"
+              "version": "3.0.2",
+              "from": "signal-exit@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
             }
           }
         },
         "minimatch": {
           "version": "3.0.3",
+          "from": "minimatch@>=3.0.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.6",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
               "dependencies": {
                 "balanced-match": {
-                  "version": "0.4.2"
+                  "version": "0.4.2",
+                  "from": "balanced-match@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                 },
                 "concat-map": {
-                  "version": "0.0.1"
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -415,138 +637,216 @@
         },
         "mkdirp": {
           "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
-              "version": "0.0.8"
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "node-emoji": {
           "version": "1.4.3",
+          "from": "node-emoji@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.3.tgz",
           "dependencies": {
             "string.prototype.codepointat": {
-              "version": "0.2.0"
+              "version": "0.2.0",
+              "from": "string.prototype.codepointat@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz"
             }
           }
         },
         "node-gyp": {
           "version": "3.4.0",
+          "from": "node-gyp@>=3.2.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
           "dependencies": {
             "fstream": {
               "version": "1.0.10",
+              "from": "fstream@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.3"
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
             "glob": {
               "version": "7.1.1",
+              "from": "glob@>=7.0.3 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "dependencies": {
                 "fs.realpath": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
                   "version": "1.0.6",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.3"
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "once": {
                   "version": "1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
               }
             },
             "graceful-fs": {
-              "version": "4.1.11"
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             },
             "nopt": {
               "version": "3.0.6",
+              "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.9"
+                  "version": "1.0.9",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                 }
               }
             },
             "npmlog": {
               "version": "3.1.2",
+              "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
+                  "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
                   "dependencies": {
                     "delegates": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "from": "delegates@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
                     "readable-stream": {
                       "version": "2.2.2",
+                      "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
                       "dependencies": {
                         "buffer-shims": {
-                          "version": "1.0.0"
+                          "version": "1.0.0",
+                          "from": "buffer-shims@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                         },
                         "core-util-is": {
-                          "version": "1.0.2"
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
-                          "version": "1.0.0"
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "inherits": {
-                          "version": "2.0.3"
+                          "version": "2.0.3",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.7"
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
-                          "version": "0.10.31"
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
-                          "version": "1.0.2"
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     }
                   }
                 },
                 "console-control-strings": {
-                  "version": "1.1.0"
+                  "version": "1.1.0",
+                  "from": "console-control-strings@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
                 },
                 "gauge": {
                   "version": "2.6.0",
+                  "from": "gauge@>=2.6.0 <2.7.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
                   "dependencies": {
                     "aproba": {
-                      "version": "1.0.4"
+                      "version": "1.0.4",
+                      "from": "aproba@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
                     },
                     "has-color": {
-                      "version": "0.1.7"
+                      "version": "0.1.7",
+                      "from": "has-color@>=0.1.7 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
                     "has-unicode": {
-                      "version": "2.0.1"
+                      "version": "2.0.1",
+                      "from": "has-unicode@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
                     },
                     "object-assign": {
-                      "version": "4.1.0"
+                      "version": "4.1.0",
+                      "from": "object-assign@>=4.1.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                     },
                     "signal-exit": {
-                      "version": "3.0.2"
+                      "version": "3.0.2",
+                      "from": "signal-exit@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
                     },
                     "string-width": {
                       "version": "1.0.2",
+                      "from": "string-width@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                       "dependencies": {
                         "code-point-at": {
-                          "version": "1.1.0"
+                          "version": "1.1.0",
+                          "from": "code-point-at@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
+                          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                           "dependencies": {
                             "number-is-nan": {
-                              "version": "1.0.1"
+                              "version": "1.0.1",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                             }
                           }
                         }
@@ -554,50 +854,76 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "2.0.0"
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "wide-align": {
-                      "version": "1.1.0"
+                      "version": "1.1.0",
+                      "from": "wide-align@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
                     }
                   }
                 },
                 "set-blocking": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "from": "set-blocking@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.1.4",
+              "from": "osenv@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
               "dependencies": {
                 "os-homedir": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
                 },
                 "os-tmpdir": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
                 }
               }
             },
             "path-array": {
               "version": "1.0.1",
+              "from": "path-array@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
               "dependencies": {
                 "array-index": {
                   "version": "1.0.0",
+                  "from": "array-index@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "3.1.0",
+                      "from": "es6-symbol@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
                       "dependencies": {
                         "d": {
-                          "version": "0.1.1"
+                          "version": "0.1.1",
+                          "from": "d@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                         },
                         "es5-ext": {
                           "version": "0.10.12",
+                          "from": "es5-ext@>=0.10.11 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
                           "dependencies": {
                             "es6-iterator": {
-                              "version": "2.0.0"
+                              "version": "2.0.0",
+                              "from": "es6-iterator@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                             }
                           }
                         }
@@ -609,50 +935,76 @@
             },
             "which": {
               "version": "1.2.12",
+              "from": "which@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
               "dependencies": {
                 "isexe": {
-                  "version": "1.1.2"
+                  "version": "1.1.2",
+                  "from": "isexe@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                 }
               }
             }
           }
         },
         "object-path": {
-          "version": "0.11.3"
+          "version": "0.11.3",
+          "from": "object-path@>=0.11.2 <0.12.0",
+          "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.3.tgz"
         },
         "proper-lockfile": {
           "version": "1.2.0",
+          "from": "proper-lockfile@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
           "dependencies": {
             "err-code": {
-              "version": "1.1.1"
+              "version": "1.1.1",
+              "from": "err-code@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.1.tgz"
             },
             "extend": {
-              "version": "3.0.0"
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "graceful-fs": {
-              "version": "4.1.11"
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             },
             "retry": {
-              "version": "0.10.1"
+              "version": "0.10.1",
+              "from": "retry@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz"
             }
           }
         },
         "read": {
           "version": "1.0.7",
+          "from": "read@>=1.0.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
           "dependencies": {
             "mute-stream": {
-              "version": "0.0.6"
+              "version": "0.0.6",
+              "from": "mute-stream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
             }
           }
         },
         "repeating": {
           "version": "2.0.1",
+          "from": "repeating@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.2",
+              "from": "is-finite@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
               "dependencies": {
                 "number-is-nan": {
-                  "version": "1.0.1"
+                  "version": "1.0.1",
+                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                 }
               }
             }
@@ -660,68 +1012,106 @@
         },
         "request": {
           "version": "2.79.0",
+          "from": "request@>=2.75.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "dependencies": {
             "aws-sign2": {
-              "version": "0.6.0"
+              "version": "0.6.0",
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
-              "version": "1.5.0"
+              "version": "1.5.0",
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
             },
             "caseless": {
-              "version": "0.11.0"
+              "version": "0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
-              "version": "3.0.0"
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
-              "version": "0.6.1"
+              "version": "0.6.1",
+              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "2.1.2",
+              "from": "form-data@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
               "dependencies": {
                 "asynckit": {
-                  "version": "0.4.0"
+                  "version": "0.4.0",
+                  "from": "asynckit@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
+              "from": "har-validator@>=2.0.6 <2.1.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
                 "is-my-json-valid": {
                   "version": "2.15.0",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
                   "dependencies": {
                     "generate-function": {
-                      "version": "2.0.0"
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
-                          "version": "1.0.2"
+                          "version": "1.0.2",
+                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
-                      "version": "4.0.0"
+                      "version": "4.0.0",
+                      "from": "jsonpointer@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
                     },
                     "xtend": {
-                      "version": "4.0.1"
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
-                      "version": "2.0.4"
+                      "version": "2.0.4",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 }
@@ -729,145 +1119,229 @@
             },
             "hawk": {
               "version": "3.1.3",
+              "from": "hawk@>=3.1.3 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.16.3"
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
-                  "version": "2.10.1"
+                  "version": "2.10.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
-                  "version": "2.0.5"
+                  "version": "2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
-                  "version": "1.0.9"
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
+              "from": "http-signature@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "dependencies": {
                 "assert-plus": {
-                  "version": "0.2.0"
+                  "version": "0.2.0",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.3.1",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                   "dependencies": {
                     "extsprintf": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
-                      "version": "0.2.3"
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                     },
                     "verror": {
-                      "version": "1.3.6"
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.10.1",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
                   "dependencies": {
                     "asn1": {
-                      "version": "0.2.3"
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "assert-plus": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "dashdash": {
-                      "version": "1.14.1"
+                      "version": "1.14.1",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                     },
                     "getpass": {
-                      "version": "0.1.6"
+                      "version": "0.1.6",
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                     },
                     "jsbn": {
-                      "version": "0.1.0"
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
-                      "version": "0.14.5"
+                      "version": "0.14.5",
+                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                     },
                     "jodid25519": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "ecc-jsbn": {
-                      "version": "0.1.1"
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
                     "bcrypt-pbkdf": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
                     }
                   }
                 }
               }
             },
             "is-typedarray": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
-              "version": "0.1.2"
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
-              "version": "5.0.1"
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.13",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.25.0"
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
             },
             "oauth-sign": {
-              "version": "0.8.2"
+              "version": "0.8.2",
+              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
             },
             "qs": {
-              "version": "6.3.0"
+              "version": "6.3.0",
+              "from": "qs@>=6.3.0 <6.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
             },
             "stringstream": {
-              "version": "0.0.5"
+              "version": "0.0.5",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
               "version": "2.3.2",
+              "from": "tough-cookie@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
               "dependencies": {
                 "punycode": {
-                  "version": "1.4.1"
+                  "version": "1.4.1",
+                  "from": "punycode@>=1.4.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                 }
               }
             },
             "tunnel-agent": {
-              "version": "0.4.3"
+              "version": "0.4.3",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             },
             "uuid": {
-              "version": "3.0.1"
+              "version": "3.0.1",
+              "from": "uuid@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
             }
           }
         },
         "request-capture-har": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "from": "request-capture-har@>=1.1.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/request-capture-har/-/request-capture-har-1.1.4.tgz"
         },
         "rimraf": {
           "version": "2.5.4",
+          "from": "rimraf@>=2.5.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
           "dependencies": {
             "glob": {
               "version": "7.1.1",
+              "from": "glob@>=7.0.5 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "dependencies": {
                 "fs.realpath": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
                   "version": "1.0.6",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.3"
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "once": {
                   "version": "1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
@@ -876,61 +1350,95 @@
           }
         },
         "roadrunner": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "from": "roadrunner@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/roadrunner/-/roadrunner-1.1.0.tgz"
         },
         "strip-bom": {
           "version": "2.0.0",
+          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "dependencies": {
             "is-utf8": {
-              "version": "0.2.1"
+              "version": "0.2.1",
+              "from": "is-utf8@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
             }
           }
         },
         "tar": {
           "version": "2.2.1",
+          "from": "tar@>=2.2.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "dependencies": {
             "block-stream": {
-              "version": "0.0.9"
+              "version": "0.0.9",
+              "from": "block-stream@*",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
             },
             "fstream": {
               "version": "1.0.10",
+              "from": "fstream@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "4.1.11"
+                  "version": "4.1.11",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                 }
               }
             },
             "inherits": {
-              "version": "2.0.3"
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
         },
         "tar-stream": {
           "version": "1.5.2",
+          "from": "tar-stream@>=1.5.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
           "dependencies": {
             "bl": {
               "version": "1.1.2",
+              "from": "bl@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.3"
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.7"
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
-                      "version": "0.10.31"
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 }
@@ -938,12 +1446,18 @@
             },
             "end-of-stream": {
               "version": "1.1.0",
+              "from": "end-of-stream@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
@@ -951,56 +1465,86 @@
             },
             "readable-stream": {
               "version": "2.2.2",
+              "from": "readable-stream@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
               "dependencies": {
                 "buffer-shims": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "buffer-shims@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                 },
                 "core-util-is": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.3"
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.7"
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
-                  "version": "0.10.31"
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
-              "version": "4.0.1"
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "user-home": {
           "version": "2.0.0",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "dependencies": {
             "os-homedir": {
-              "version": "1.0.2"
+              "version": "1.0.2",
+              "from": "os-homedir@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
+          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
+              "from": "spdx-correct@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
               "dependencies": {
                 "spdx-license-ids": {
-                  "version": "1.2.2"
+                  "version": "1.2.2",
+                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
                 }
               }
             },
             "spdx-expression-parse": {
-              "version": "1.0.4"
+              "version": "1.0.4",
+              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
             }
           }
         }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nsp",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,146 +1,2593 @@
 {
   "name": "nsp",
   "version": "2.7.0",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "abbrev": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "dev": true,
+      "optional": true
+    },
+    "acorn": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bossy": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bossy/-/bossy-1.0.3.tgz",
+      "integrity": "sha1-p9JHiuDC33X0cJi5ute9ZB7tX68=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.1"
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "escape-string-regexp": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "has-ansi": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "requires": {
+            "ansi-regex": "2.0.0"
+          },
           "dependencies": {
             "ansi-regex": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
             }
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.0.0"
+          },
           "dependencies": {
             "ansi-regex": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
             }
           }
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-table": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "requires": {
+        "colors": "1.0.3"
+      },
       "dependencies": {
         "colors": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         }
       }
     },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/code/-/code-1.5.0.tgz",
+      "integrity": "sha1-1hWfvQ7p+ERRZ4CdQ7XNm8QFEDo=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "cvss": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.1.tgz",
+      "integrity": "sha1-XAffU2FqxW1m6PR0vtJePBRhk9s="
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.30"
+      }
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
+    },
+    "diff": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+      "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.30",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
+      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "1.5.0",
+        "es6-map": "0.1.5",
+        "escope": "3.6.0",
+        "espree": "3.5.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.5",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.9.1",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "optionator": "0.8.2",
+        "path-is-absolute": "1.0.0",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.6.1",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      }
+    },
+    "eslint-config-hapi": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-3.0.2.tgz",
+      "integrity": "sha1-Wk+tJQeELM0phRtjrwWitbFnw2c=",
+      "dev": true
+    },
+    "eslint-config-nodesecurity": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-nodesecurity/-/eslint-config-nodesecurity-1.3.1.tgz",
+      "integrity": "sha1-8IAQ/DDJZPrdG0Yi5mO8Dx8P7Uk=",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-hapi": "4.0.0"
+      },
+      "dependencies": {
+        "eslint-plugin-hapi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.0.0.tgz",
+          "integrity": "sha1-RKouRfeTmlI5Kc2DK7mqEpqV6CM=",
+          "dev": true,
+          "requires": {
+            "hapi-capitalize-modules": "1.1.6",
+            "hapi-for-you": "1.0.0",
+            "hapi-scope-start": "2.1.1",
+            "no-arrowception": "1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-hapi": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-1.2.2.tgz",
+      "integrity": "sha1-QcwGNDhxibEcAGdWM6cVZGq4lJA=",
+      "dev": true,
+      "requires": {
+        "hapi-capitalize-modules": "1.1.6",
+        "hapi-scope-start": "1.1.4",
+        "no-shadow-relaxed": "1.0.1"
+      },
+      "dependencies": {
+        "hapi-scope-start": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-1.1.4.tgz",
+          "integrity": "sha1-VxC1r7dOdJYdrn6wmdjYvkp1sA4=",
+          "dev": true
+        }
+      }
+    },
+    "espree": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "estraverse-fb": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+      "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true,
+      "optional": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "get-stdin": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
+      "integrity": "sha1-wc7SS5A5s43thb3xYeV3E7bdSr4=",
+      "dev": true
+    },
+    "git-validate": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/git-validate/-/git-validate-2.2.2.tgz",
+      "integrity": "sha1-nMj/ABF3lXoRcmq1CNQVu4Cxi88=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.0"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      }
+    },
+    "hapi-capitalize-modules": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
+      "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
+      "dev": true
+    },
+    "hapi-for-you": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
+      "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
+      "dev": true
+    },
+    "hapi-scope-start": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
+      "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
     },
     "https-proxy-agent": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "requires": {
+        "agent-base": "2.0.1",
+        "debug": "2.2.0",
+        "extend": "3.0.0"
+      },
       "dependencies": {
         "agent-base": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+          "integrity": "sha1-vY+ehqjrIh//oHvRS+/VXfFCgV4=",
+          "requires": {
+            "extend": "3.0.0",
+            "semver": "5.0.3"
+          },
           "dependencies": {
             "semver": {
-              "version": "5.0.3"
+              "version": "5.0.3",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+              "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
             }
           }
         },
         "debug": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "0.7.1"
+          },
           "dependencies": {
             "ms": {
-              "version": "0.7.1"
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
             }
           }
         },
         "extend": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
         }
       }
     },
+    "ignore": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-my-json-valid": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "items": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-1.1.1.tgz",
+      "integrity": "sha1-Q1td0hvKKLPP0lu1xrJ4txUBD9k=",
+      "dev": true
+    },
     "joi": {
       "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
+      "requires": {
+        "hoek": "2.16.3",
+        "isemail": "1.2.0",
+        "moment": "2.12.0",
+        "topo": "1.1.0"
+      },
       "dependencies": {
         "hoek": {
-          "version": "2.16.3"
-        },
-        "topo": {
-          "version": "1.1.0"
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
         "isemail": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
         },
         "moment": {
-          "version": "2.12.0"
+          "version": "2.12.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
+          "integrity": "sha1-3CVg0Zg41sBzGxpq+gRnUmTTYNY="
+        },
+        "topo": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "jslint": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/jslint/-/jslint-0.9.8.tgz",
+      "integrity": "sha1-uSyoXKhtaoKXchCO6RnshJ3EsSk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "4.5.3",
+        "nopt": "3.0.6",
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
+    },
+    "lab": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lab/-/lab-6.2.0.tgz",
+      "integrity": "sha1-RonomYv3V1YH0nNpgmjRXMWe3Qg=",
+      "dev": true,
+      "requires": {
+        "bossy": "1.0.3",
+        "diff": "2.2.3",
+        "eslint": "1.5.1",
+        "eslint-config-hapi": "3.0.2",
+        "eslint-plugin-hapi": "1.2.2",
+        "espree": "2.2.5",
+        "handlebars": "4.0.10",
+        "hoek": "2.16.3",
+        "items": "1.1.1",
+        "jslint": "0.9.8",
+        "json-stringify-safe": "5.0.1",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.3.3"
+      },
+      "dependencies": {
+        "cli-width": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+          "dev": true
+        },
+        "doctrine": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+          "dev": true,
+          "requires": {
+            "esutils": "1.1.6",
+            "isarray": "0.0.1"
+          }
+        },
+        "eslint": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
+          "integrity": "sha1-u54WHwFh1xuF3EgWO/FKhvICVis=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "debug": "2.6.8",
+            "doctrine": "0.7.2",
+            "escape-string-regexp": "1.0.5",
+            "escope": "3.6.0",
+            "espree": "2.2.5",
+            "estraverse": "4.2.0",
+            "estraverse-fb": "1.3.2",
+            "file-entry-cache": "1.3.1",
+            "glob": "5.0.15",
+            "globals": "8.18.0",
+            "handlebars": "4.0.10",
+            "inquirer": "0.9.0",
+            "is-my-json-valid": "2.16.1",
+            "is-resolvable": "1.0.0",
+            "js-yaml": "3.9.1",
+            "lodash.clonedeep": "3.0.2",
+            "lodash.merge": "3.3.2",
+            "lodash.omit": "3.1.0",
+            "minimatch": "2.0.10",
+            "mkdirp": "0.5.1",
+            "object-assign": "2.1.1",
+            "optionator": "0.5.0",
+            "path-is-absolute": "1.0.0",
+            "path-is-inside": "1.0.2",
+            "shelljs": "0.3.0",
+            "strip-json-comments": "1.0.4",
+            "text-table": "0.2.0",
+            "to-double-quotes": "1.0.2",
+            "to-single-quotes": "1.0.4",
+            "user-home": "1.1.1",
+            "xml-escape": "1.0.0"
+          }
+        },
+        "espree": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "fast-levenshtein": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+          "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.0"
+          }
+        },
+        "globals": {
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+          "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
+          "integrity": "sha1-c2bjijMeYZBJWKzlstpKml9jZ5g=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.10.1",
+            "readline2": "0.1.1",
+            "run-async": "0.1.0",
+            "rx-lite": "2.5.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+          "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+          "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.0.7",
+            "levn": "0.2.5",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "readline2": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+          "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+          "dev": true,
+          "requires": {
+            "mute-stream": "0.0.4",
+            "strip-ansi": "2.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "1.1.1"
+              }
+            }
+          }
+        },
+        "rx-lite": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
+          "integrity": "sha1-X+9C1Nbna6tRmdIXEyfbcJ5Y5jQ=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+          "dev": true
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "dev": true
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "dev": true
+    },
+    "lodash._arraymap": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._baseassign": "3.2.0",
+        "lodash._basefor": "3.0.3",
+        "lodash.isarray": "3.0.4",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basedifference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+      "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+      "dev": true,
+      "requires": {
+        "lodash._baseindexof": "3.1.0",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2"
+      }
+    },
+    "lodash._baseflatten": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+      "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "dev": true
+    },
+    "lodash._baseindexof": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+      "dev": true
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
+    },
+    "lodash._cacheindexof": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+      "dev": true
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash._createcache": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1"
+      }
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._pickbyarray": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+      "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
+      "dev": true
+    },
+    "lodash._pickbycallback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+      "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "dev": true,
+      "requires": {
+        "lodash._baseclone": "3.3.0",
+        "lodash._bindcallback": "3.0.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.isarguments": "3.1.0",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.merge": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4",
+        "lodash.isplainobject": "3.2.0",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2",
+        "lodash.keysin": "3.0.8",
+        "lodash.toplainobject": "3.0.0"
+      }
+    },
+    "lodash.omit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+      "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
+      "dev": true,
+      "requires": {
+        "lodash._arraymap": "3.0.0",
+        "lodash._basedifference": "3.0.3",
+        "lodash._baseflatten": "3.1.4",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._pickbyarray": "3.0.2",
+        "lodash._pickbycallback": "3.0.0",
+        "lodash.keysin": "3.0.8",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.toplainobject": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "no-arrowception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
+      "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
+      "dev": true
+    },
+    "no-shadow-relaxed": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/no-shadow-relaxed/-/no-shadow-relaxed-1.0.1.tgz",
+      "integrity": "sha1-z2zAFAL0IwuE/TvYoVZG3d8i7fI=",
+      "dev": true,
+      "requires": {
+        "eslint": "0.24.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+          "dev": true
+        },
+        "cli-width": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+          "dev": true
+        },
+        "doctrine": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
+          "integrity": "sha1-gUKEkalC7xiwSSBW7aOADu5X1h0=",
+          "dev": true,
+          "requires": {
+            "esutils": "1.1.6",
+            "isarray": "0.0.1"
+          }
+        },
+        "eslint": {
+          "version": "0.24.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.24.1.tgz",
+          "integrity": "sha1-VKUICYVbllVyHG8u5Xs1HtzigQE=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "debug": "2.6.8",
+            "doctrine": "0.6.4",
+            "escape-string-regexp": "1.0.5",
+            "escope": "3.6.0",
+            "espree": "2.2.5",
+            "estraverse": "4.2.0",
+            "estraverse-fb": "1.3.2",
+            "globals": "8.18.0",
+            "inquirer": "0.8.5",
+            "is-my-json-valid": "2.16.1",
+            "js-yaml": "3.9.1",
+            "minimatch": "2.0.10",
+            "mkdirp": "0.5.1",
+            "object-assign": "2.1.1",
+            "optionator": "0.5.0",
+            "path-is-absolute": "1.0.0",
+            "strip-json-comments": "1.0.4",
+            "text-table": "0.2.0",
+            "user-home": "1.1.1",
+            "xml-escape": "1.0.0"
+          }
+        },
+        "espree": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "fast-levenshtein": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+          "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+          "dev": true
+        },
+        "globals": {
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+          "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+          "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "1.1.1",
+            "chalk": "1.1.3",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.10.1",
+            "readline2": "0.1.1",
+            "rx": "2.5.3",
+            "through": "2.3.8"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+          "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+          "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.0.7",
+            "levn": "0.2.5",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "readline2": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+          "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+          "dev": true,
+          "requires": {
+            "mute-stream": "0.0.4",
+            "strip-ansi": "2.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "1.1.1"
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "nock": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-7.7.3.tgz",
+      "integrity": "sha1-0GAJgKREPt9uULXtMxRgLLfMxIk=",
+      "dev": true,
+      "requires": {
+        "chai": "3.5.0",
+        "debug": "2.6.8",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "3.10.1",
+        "mkdirp": "0.5.1",
+        "propagate": "0.3.1",
+        "qs": "6.5.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
         }
       }
     },
     "nodesecurity-npm-utils": {
-      "version": "5.0.0"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz",
+      "integrity": "sha1-Baow3jDKjIRcQEjpT9eOXgi1Xtk="
     },
-    "path-is-absolute": {
-      "version": "1.0.0"
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "abbrev": "1.1.0"
+      }
     },
-    "rc": {
-      "version": "1.1.6",
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
-        "deep-extend": {
-          "version": "0.4.1"
-        },
-        "ini": {
-          "version": "1.3.4"
-        },
-        "minimist": {
-          "version": "1.2.0"
-        },
-        "strip-json-comments": {
-          "version": "1.0.4"
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
         }
       }
     },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "propagate": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
+      "integrity": "sha1-46hEBKfs6CDda76p9tkk4xNa4Jw=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+      "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+      "requires": {
+        "deep-extend": "0.4.1",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "1.0.4"
+      },
+      "dependencies": {
+        "deep-extend": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
+        },
+        "ini": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "rx": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
+      "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
     "semver": {
-      "version": "5.1.0"
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+      "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
+    },
+    "shelljs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+      "dev": true
+    },
+    "shrinkydink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/shrinkydink/-/shrinkydink-1.0.1.tgz",
+      "integrity": "sha1-3IbklqHndptP4GIYm89s18TxhIY=",
+      "dev": true,
+      "requires": {
+        "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "source-map-support": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
+      "integrity": "sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.1.32"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+          "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
     },
     "subcommand": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
+      "integrity": "sha1-mz/Rp1PjxEHwBBDLRBMdhlX1LDI=",
+      "requires": {
+        "cliclopts": "1.1.1",
+        "debug": "2.2.0",
+        "minimist": "1.2.0",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "cliclopts": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
+          "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8="
         },
         "debug": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "0.7.1"
+          },
           "dependencies": {
             "ms": {
-              "version": "0.7.1"
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
             }
           }
         },
         "minimist": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "xtend": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
+    "table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "to-double-quotes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
+      "integrity": "sha1-u27TbHhjTD1k/YelGtWGDcWU7f0=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "3.0.2"
+      }
+    },
+    "to-single-quotes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
+      "integrity": "sha1-LuqBma8myhFx9TV8WeGS1WXuUxM=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "3.0.2"
+      }
+    },
+    "tryit": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
     "wreck": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
+      "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
+      "requires": {
+        "boom": "2.10.1",
+        "hoek": "2.16.3"
+      },
       "dependencies": {
-        "hoek": {
-          "version": "2.16.3"
-        },
         "boom": {
-          "version": "2.10.1"
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         }
+      }
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "xml-escape": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+      "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
       }
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,617 +2,121 @@
   "name": "nsp",
   "version": "2.8.0",
   "dependencies": {
-    "abbrev": {
-      "version": "1.1.0",
-      "from": "abbrev@1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+    "@yarnpkg/lockfile": {
+      "version": "1.0.0",
+      "from": "@yarnpkg/lockfile@latest",
+      "resolved": "http://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.0.0.tgz"
     },
     "agent-base": {
       "version": "2.1.1",
-      "from": "agent-base@2",
+      "from": "agent-base@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "dependencies": {
         "semver": {
           "version": "5.0.3",
-          "from": "semver@~5.0.1",
+          "from": "semver@>=5.0.1 <5.1.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
         }
       }
     },
-    "ajv": {
-      "version": "4.11.8",
-      "from": "ajv@^4.9.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
-    },
-    "ansi-escapes": {
-      "version": "1.4.0",
-      "from": "ansi-escapes@^1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
-    },
     "ansi-regex": {
       "version": "2.1.1",
-      "from": "ansi-regex@^2.0.0",
+      "from": "ansi-regex@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "from": "ansi-styles@^2.2.1",
+      "from": "ansi-styles@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-    },
-    "aproba": {
-      "version": "1.1.2",
-      "from": "aproba@^1.0.3",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
-    },
-    "are-we-there-yet": {
-      "version": "1.1.4",
-      "from": "are-we-there-yet@~1.1.2",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "from": "array-find-index@^1.0.1",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "from": "asn1@~0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "from": "assert-plus@^0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "from": "asynckit@^0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-    },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "from": "aws-sign2@~0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "from": "aws4@^1.2.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "from": "babel-runtime@^6.0.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "from": "balanced-match@^1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "from": "bcrypt-pbkdf@^1.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "optional": true
-    },
-    "bl": {
-      "version": "1.2.1",
-      "from": "bl@^1.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz"
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "from": "block-stream@*",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
     },
     "boom": {
       "version": "2.10.1",
-      "from": "boom@2.x.x",
+      "from": "boom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-    },
-    "brace-expansion": {
-      "version": "1.1.8",
-      "from": "brace-expansion@^1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "from": "builtin-modules@^1.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-    },
-    "bytes": {
-      "version": "2.5.0",
-      "from": "bytes@^2.4.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz"
-    },
-    "camelcase": {
-      "version": "3.0.0",
-      "from": "camelcase@^3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "from": "caseless@~0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@^1.1.1",
+      "from": "chalk@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-    },
-    "ci-info": {
-      "version": "1.1.1",
-      "from": "ci-info@^1.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz"
-    },
-    "cli-cursor": {
-      "version": "1.0.2",
-      "from": "cli-cursor@^1.0.1",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-table": {
       "version": "0.3.1",
-      "from": "cli-table@^0.3.1",
+      "from": "cli-table@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "from": "cli-width@^2.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz"
     },
     "cliclopts": {
       "version": "1.1.1",
-      "from": "cliclopts@^1.1.0",
+      "from": "cliclopts@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz"
-    },
-    "clone": {
-      "version": "1.0.2",
-      "from": "clone@^1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-    },
-    "cmd-shim": {
-      "version": "2.0.2",
-      "from": "cmd-shim@^2.0.1",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz"
-    },
-    "co": {
-      "version": "4.6.0",
-      "from": "co@^4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "from": "code-point-at@^1.0.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
     },
     "colors": {
       "version": "1.0.3",
       "from": "colors@1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
     },
-    "combined-stream": {
-      "version": "1.0.5",
-      "from": "combined-stream@~1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-    },
-    "commander": {
-      "version": "2.11.0",
-      "from": "commander@^2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-    },
-    "concat-stream": {
-      "version": "1.6.0",
-      "from": "concat-stream@^1.4.7",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz"
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "from": "console-control-strings@~1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-    },
-    "core-js": {
-      "version": "2.5.1",
-      "from": "core-js@^2.4.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "from": "core-util-is@~1.0.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "from": "cryptiles@2.x.x",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "from": "currently-unhandled@^0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
-    },
     "cvss": {
       "version": "1.0.2",
-      "from": "cvss@^1.0.0",
-      "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.2.tgz"
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "from": "dashdash@^1.12.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@^1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-        }
-      }
-    },
-    "death": {
-      "version": "1.1.0",
-      "from": "death@^1.0.0",
-      "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz"
+      "from": "cvss@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/cvss/-/cvss-1.0.2.tgz"
     },
     "debug": {
       "version": "2.6.8",
-      "from": "debug@2",
+      "from": "debug@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
     },
     "deep-extend": {
       "version": "0.4.2",
-      "from": "deep-extend@~0.4.0",
+      "from": "deep-extend@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
-    },
-    "defaults": {
-      "version": "1.0.3",
-      "from": "defaults@^1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "from": "delayed-stream@~1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "from": "delegates@^1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-    },
-    "detect-indent": {
-      "version": "4.0.0",
-      "from": "detect-indent@^4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
-    },
-    "diff": {
-      "version": "2.2.3",
-      "from": "diff@^2.2.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "from": "ecc-jsbn@~0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "optional": true
-    },
-    "end-of-stream": {
-      "version": "1.4.0",
-      "from": "end-of-stream@^1.0.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz"
-    },
-    "err-code": {
-      "version": "1.1.2",
-      "from": "err-code@^1.0.0",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "escape-string-regexp@^1.0.2",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "from": "exit-hook@^1.0.0",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "extend": {
       "version": "3.0.1",
-      "from": "extend@3",
+      "from": "extend@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
-    },
-    "external-editor": {
-      "version": "1.1.1",
-      "from": "external-editor@^1.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz"
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "from": "extsprintf@1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
-    },
-    "figures": {
-      "version": "1.7.0",
-      "from": "figures@^1.3.5",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "from": "forever-agent@~0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-    },
-    "form-data": {
-      "version": "2.1.4",
-      "from": "form-data@~2.1.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "from": "fs.realpath@^1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-    },
-    "fstream": {
-      "version": "1.0.11",
-      "from": "fstream@^1.0.0",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "from": "gauge@~2.7.3",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "from": "getpass@^0.1.1",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@^1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-        }
-      }
-    },
-    "glob": {
-      "version": "7.1.2",
-      "from": "glob@^7.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "from": "graceful-fs@^4.1.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-    },
-    "har-schema": {
-      "version": "1.0.5",
-      "from": "har-schema@^1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-    },
-    "har-validator": {
-      "version": "4.2.1",
-      "from": "har-validator@~4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "has-ansi@^2.0.0",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "from": "has-unicode@^2.0.0",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "from": "hawk@~3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "hoek": {
       "version": "2.16.3",
-      "from": "hoek@2.x.x",
+      "from": "hoek@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-    },
-    "http-signature": {
-      "version": "1.1.1",
-      "from": "http-signature@~1.1.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "https-proxy-agent": {
       "version": "1.0.0",
-      "from": "https-proxy-agent@^1.0.0",
+      "from": "https-proxy-agent@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "from": "inflight@^1.0.4",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "from": "inherits@^2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@~1.3.0",
+      "from": "ini@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-    },
-    "inquirer": {
-      "version": "1.2.3",
-      "from": "inquirer@^1.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz"
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "from": "invariant@^2.2.0",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "from": "is-builtin-module@^1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-    },
-    "is-ci": {
-      "version": "1.0.10",
-      "from": "is-ci@^1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz"
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "from": "is-finite@^1.0.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "from": "is-fullwidth-code-point@^1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "from": "is-promise@^2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "from": "is-typedarray@~1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "from": "is-utf8@^0.2.0",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "from": "isarray@~1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "isemail": {
       "version": "1.2.0",
-      "from": "isemail@1.x.x",
+      "from": "isemail@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "from": "isexe@^2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "from": "isstream@~0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "joi": {
       "version": "6.10.1",
-      "from": "joi@^6.9.1",
+      "from": "joi@>=6.9.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz"
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "from": "js-tokens@^3.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "from": "jsbn@~0.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "from": "json-schema@0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "from": "json-stable-stringify@^1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "from": "json-stringify-safe@~5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "from": "jsonify@~0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "from": "jsprim@^1.2.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-        }
-      }
-    },
-    "leven": {
-      "version": "2.1.0",
-      "from": "leven@^2.0.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz"
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "from": "lodash@^4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-    },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "from": "lodash.toarray@^4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz"
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "from": "loose-envify@^1.0.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "from": "loud-rejection@^1.2.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
-    },
-    "mime-db": {
-      "version": "1.30.0",
-      "from": "mime-db@~1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
-    },
-    "mime-types": {
-      "version": "2.1.17",
-      "from": "mime-types@~2.1.7",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "from": "minimatch@^3.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
     },
     "minimist": {
       "version": "1.2.0",
-      "from": "minimist@^1.2.0",
+      "from": "minimist@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "from": "mkdirp@^0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        }
-      }
     },
     "moment": {
       "version": "2.18.1",
-      "from": "moment@2.x.x",
+      "from": "moment@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
     },
     "ms": {
@@ -620,402 +124,60 @@
       "from": "ms@2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
     },
-    "mute-stream": {
-      "version": "0.0.6",
-      "from": "mute-stream@0.0.6",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
-    },
-    "node-emoji": {
-      "version": "1.8.1",
-      "from": "node-emoji@^1.0.4",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz"
-    },
-    "node-gyp": {
-      "version": "3.6.2",
-      "from": "node-gyp@^3.2.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "from": "semver@~5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-        }
-      }
-    },
     "nodesecurity-npm-utils": {
       "version": "5.0.0",
-      "from": "nodesecurity-npm-utils@^5.0.0",
+      "from": "nodesecurity-npm-utils@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz"
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "from": "nopt@2 || 3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "from": "npmlog@0 || 1 || 2 || 3 || 4",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz"
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "from": "number-is-nan@^1.0.0",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "from": "oauth-sign@~0.8.1",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "from": "object-assign@^4.1.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-    },
-    "object-path": {
-      "version": "0.11.4",
-      "from": "object-path@^0.11.2",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz"
-    },
-    "once": {
-      "version": "1.4.0",
-      "from": "once@^1.3.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-    },
-    "onetime": {
-      "version": "1.1.0",
-      "from": "onetime@^1.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "from": "os-homedir@^1.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "from": "os-shim@^0.1.2",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "from": "os-tmpdir@~1.0.1",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-    },
-    "osenv": {
-      "version": "0.1.4",
-      "from": "osenv@0",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@^1.0.0",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-    },
-    "performance-now": {
-      "version": "0.2.0",
-      "from": "performance-now@^0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "from": "pinkie@^2.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "from": "pinkie-promise@^2.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "from": "process-nextick-args@~1.0.6",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-    },
-    "proper-lockfile": {
-      "version": "1.2.0",
-      "from": "proper-lockfile@^1.1.3",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz"
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "from": "punycode@^1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-    },
-    "qs": {
-      "version": "6.4.0",
-      "from": "qs@~6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
     },
     "rc": {
       "version": "1.2.1",
-      "from": "rc@^1.1.2",
+      "from": "rc@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz"
-    },
-    "read": {
-      "version": "1.0.7",
-      "from": "read@^1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz"
-    },
-    "readable-stream": {
-      "version": "2.3.3",
-      "from": "readable-stream@^2.2.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
-    },
-    "regenerator-runtime": {
-      "version": "0.11.0",
-      "from": "regenerator-runtime@^0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "from": "repeating@^2.0.0",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-    },
-    "request": {
-      "version": "2.81.0",
-      "from": "request@^2.75.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
-    },
-    "request-capture-har": {
-      "version": "1.2.2",
-      "from": "request-capture-har@^1.1.4",
-      "resolved": "https://registry.npmjs.org/request-capture-har/-/request-capture-har-1.2.2.tgz"
-    },
-    "restore-cursor": {
-      "version": "1.0.1",
-      "from": "restore-cursor@^1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
-    },
-    "retry": {
-      "version": "0.10.1",
-      "from": "retry@^0.10.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz"
-    },
-    "rimraf": {
-      "version": "2.6.1",
-      "from": "rimraf@^2.5.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-    },
-    "roadrunner": {
-      "version": "1.1.0",
-      "from": "roadrunner@^1.1.0",
-      "resolved": "https://registry.npmjs.org/roadrunner/-/roadrunner-1.1.0.tgz"
-    },
-    "run-async": {
-      "version": "2.3.0",
-      "from": "run-async@^2.2.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz"
-    },
-    "rx": {
-      "version": "4.1.0",
-      "from": "rx@^4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "from": "safe-buffer@~5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
     },
     "semver": {
       "version": "5.4.1",
-      "from": "semver@^5.0.3",
+      "from": "semver@>=5.0.3 <6.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "from": "set-blocking@~2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "from": "signal-exit@^3.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "from": "sntp@1.x.x",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-    },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "from": "spawn-sync@^1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz"
-    },
-    "spdx-correct": {
-      "version": "1.0.2",
-      "from": "spdx-correct@~1.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
-    },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "from": "spdx-expression-parse@~1.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-    },
-    "spdx-license-ids": {
-      "version": "1.2.2",
-      "from": "spdx-license-ids@^1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "from": "sshpk@^1.7.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@^1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-        }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "from": "string_decoder@~1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "from": "string-width@^1.0.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "from": "stringstream@~0.0.4",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@^3.0.0",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "from": "strip-bom@^2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "from": "strip-json-comments@~2.0.1",
+      "from": "strip-json-comments@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
     },
     "subcommand": {
       "version": "2.1.0",
-      "from": "subcommand@^2.0.3",
-      "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.1.0.tgz"
+      "from": "subcommand@>=2.0.3 <3.0.0",
+      "resolved": "http://registry.npmjs.org/subcommand/-/subcommand-2.1.0.tgz"
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "supports-color@^2.0.0",
+      "from": "supports-color@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-    },
-    "tar": {
-      "version": "2.2.1",
-      "from": "tar@^2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-    },
-    "tar-stream": {
-      "version": "1.5.4",
-      "from": "tar-stream@^1.5.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz"
-    },
-    "through": {
-      "version": "2.3.8",
-      "from": "through@^2.3.6",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-    },
-    "tmp": {
-      "version": "0.0.29",
-      "from": "tmp@^0.0.29",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz"
     },
     "topo": {
       "version": "1.1.0",
-      "from": "topo@1.x.x",
+      "from": "topo@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
-    },
-    "tough-cookie": {
-      "version": "2.3.2",
-      "from": "tough-cookie@~2.3.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "from": "tunnel-agent@^0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "from": "tweetnacl@~0.14.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "optional": true
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "from": "typedarray@^0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "from": "user-home@^2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "from": "util-deprecate@~1.0.1",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "from": "uuid@^3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "from": "validate-npm-package-license@^3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-    },
-    "verror": {
-      "version": "1.10.0",
-      "from": "verror@1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@^1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-        }
-      }
-    },
-    "which": {
-      "version": "1.3.0",
-      "from": "which@1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
-    },
-    "wide-align": {
-      "version": "1.1.2",
-      "from": "wide-align@^1.1.0",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "from": "wrappy@1",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "wreck": {
       "version": "6.3.0",
-      "from": "wreck@^6.3.0",
+      "from": "wreck@>=6.3.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz"
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@^4.0.0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-    },
-    "yarn": {
-      "version": "0.18.2",
-      "from": "yarn@^0.18.1",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-0.18.2.tgz"
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -139,6 +139,872 @@
           "version": "2.10.1"
         }
       }
+    },
+    "yarn": {
+      "version": "0.17.10",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.20.0",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1"
+            },
+            "regenerator-runtime": {
+              "version": "0.10.1"
+            }
+          }
+        },
+        "bytes": {
+          "version": "2.4.0"
+        },
+        "camelcase": {
+          "version": "3.0.0"
+        },
+        "cmd-shim": {
+          "version": "2.0.2",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.11"
+            }
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "death": {
+          "version": "1.0.0"
+        },
+        "debug": {
+          "version": "2.4.4",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.2"
+            }
+          }
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2"
+            }
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0"
+        },
+        "diff": {
+          "version": "2.2.3"
+        },
+        "ini": {
+          "version": "1.3.4"
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0"
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1"
+                    },
+                    "onetime": {
+                      "version": "1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "2.1.0"
+            },
+            "external-editor": {
+              "version": "1.1.1",
+              "dependencies": {
+                "extend": {
+                  "version": "3.0.0"
+                },
+                "spawn-sync": {
+                  "version": "1.0.15",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.5.2",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.3"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.6",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2"
+                            },
+                            "isarray": {
+                              "version": "1.0.0"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "os-shim": {
+                      "version": "0.1.3"
+                    }
+                  }
+                },
+                "tmp": {
+                  "version": "0.0.29",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.5"
+                },
+                "object-assign": {
+                  "version": "4.1.0"
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.17.2"
+            },
+            "mute-stream": {
+              "version": "0.0.6"
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "dependencies": {
+                "pinkie": {
+                  "version": "2.0.4"
+                }
+              }
+            },
+            "run-async": {
+              "version": "2.3.0",
+              "dependencies": {
+                "is-promise": {
+                  "version": "2.1.0"
+                }
+              }
+            },
+            "rx": {
+              "version": "4.1.0"
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0"
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "through": {
+              "version": "2.3.8"
+            }
+          }
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.3.0",
+              "dependencies": {
+                "js-tokens": {
+                  "version": "2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "dependencies": {
+            "builtin-modules": {
+              "version": "1.1.1"
+            }
+          }
+        },
+        "is-ci": {
+          "version": "1.0.10",
+          "dependencies": {
+            "ci-info": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "leven": {
+          "version": "2.0.0"
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "dependencies": {
+            "currently-unhandled": {
+              "version": "0.4.1",
+              "dependencies": {
+                "array-find-index": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "signal-exit": {
+              "version": "3.0.2"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.6",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.4.2"
+                },
+                "concat-map": {
+                  "version": "0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8"
+            }
+          }
+        },
+        "node-emoji": {
+          "version": "1.4.3",
+          "dependencies": {
+            "string.prototype.codepointat": {
+              "version": "0.2.0"
+            }
+          }
+        },
+        "node-gyp": {
+          "version": "3.4.0",
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.10",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3"
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.1",
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0"
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3"
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11"
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "npmlog": {
+              "version": "3.1.2",
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0"
+                    },
+                    "readable-stream": {
+                      "version": "2.2.2",
+                      "dependencies": {
+                        "buffer-shims": {
+                          "version": "1.0.0"
+                        },
+                        "core-util-is": {
+                          "version": "1.0.2"
+                        },
+                        "isarray": {
+                          "version": "1.0.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.3"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0"
+                },
+                "gauge": {
+                  "version": "2.6.0",
+                  "dependencies": {
+                    "aproba": {
+                      "version": "1.0.4"
+                    },
+                    "has-color": {
+                      "version": "0.1.7"
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1"
+                    },
+                    "object-assign": {
+                      "version": "4.1.0"
+                    },
+                    "signal-exit": {
+                      "version": "3.0.2"
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0"
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.0"
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "path-array": {
+              "version": "1.0.1",
+              "dependencies": {
+                "array-index": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "3.1.0",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.12",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.12",
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2"
+                }
+              }
+            }
+          }
+        },
+        "object-path": {
+          "version": "0.11.3"
+        },
+        "proper-lockfile": {
+          "version": "1.2.0",
+          "dependencies": {
+            "err-code": {
+              "version": "1.1.1"
+            },
+            "extend": {
+              "version": "3.0.0"
+            },
+            "graceful-fs": {
+              "version": "4.1.11"
+            },
+            "retry": {
+              "version": "0.10.1"
+            }
+          }
+        },
+        "read": {
+          "version": "1.0.7",
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.6"
+            }
+          }
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "dependencies": {
+            "is-finite": {
+              "version": "1.0.2",
+              "dependencies": {
+                "number-is-nan": {
+                  "version": "1.0.1"
+                }
+              }
+            }
+          }
+        },
+        "request": {
+          "version": "2.79.0",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0"
+            },
+            "aws4": {
+              "version": "1.5.0"
+            },
+            "caseless": {
+              "version": "0.11.0"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0"
+            },
+            "forever-agent": {
+              "version": "0.6.1"
+            },
+            "form-data": {
+              "version": "2.1.2",
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "dependencies": {
+                "is-my-json-valid": {
+                  "version": "2.15.0",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.0"
+                    },
+                    "xtend": {
+                      "version": "4.0.1"
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3"
+                },
+                "boom": {
+                  "version": "2.10.1"
+                },
+                "cryptiles": {
+                  "version": "2.0.5"
+                },
+                "sntp": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0"
+                },
+                "jsprim": {
+                  "version": "1.3.1",
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3"
+                    },
+                    "verror": {
+                      "version": "1.3.6"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.10.1",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0"
+                    },
+                    "dashdash": {
+                      "version": "1.14.1"
+                    },
+                    "getpass": {
+                      "version": "0.1.6"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0"
+            },
+            "isstream": {
+              "version": "0.1.2"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1"
+            },
+            "mime-types": {
+              "version": "2.1.13",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.25.0"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2"
+            },
+            "qs": {
+              "version": "6.3.0"
+            },
+            "stringstream": {
+              "version": "0.0.5"
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1"
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.4.3"
+            },
+            "uuid": {
+              "version": "3.0.1"
+            }
+          }
+        },
+        "request-capture-har": {
+          "version": "1.1.4"
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "dependencies": {
+            "glob": {
+              "version": "7.1.1",
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0"
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3"
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "roadrunner": {
+          "version": "1.1.0"
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "dependencies": {
+            "is-utf8": {
+              "version": "0.2.1"
+            }
+          }
+        },
+        "tar": {
+          "version": "2.2.1",
+          "dependencies": {
+            "block-stream": {
+              "version": "0.0.9"
+            },
+            "fstream": {
+              "version": "1.0.10",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.11"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3"
+            }
+          }
+        },
+        "tar-stream": {
+          "version": "1.5.2",
+          "dependencies": {
+            "bl": {
+              "version": "1.1.2",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2"
+                    },
+                    "inherits": {
+                      "version": "2.0.3"
+                    },
+                    "isarray": {
+                      "version": "1.0.0"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "end-of-stream": {
+              "version": "1.1.0",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.3",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.2.2",
+              "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0"
+                },
+                "core-util-is": {
+                  "version": "1.0.2"
+                },
+                "isarray": {
+                  "version": "1.0.0"
+                },
+                "inherits": {
+                  "version": "2.0.3"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7"
+                },
+                "string_decoder": {
+                  "version": "0.10.31"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.1"
+            }
+          }
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2"
+            }
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "dependencies": {
+            "spdx-correct": {
+              "version": "1.0.2",
+              "dependencies": {
+                "spdx-license-ids": {
+                  "version": "1.2.2"
+                }
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "1.0.4"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -217,9 +217,9 @@
       }
     },
     "yarn": {
-      "version": "0.19.0-0",
-      "from": "methyl/yarn",
-      "resolved": "git://github.com/methyl/yarn.git#56e790fab9d218099e17e3170cc4c37d63d5b586",
+      "version": "0.18.1",
+      "from": "yarn@latest",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-0.18.1.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "6.20.0",
@@ -278,9 +278,9 @@
           "resolved": "https://registry.npmjs.org/death/-/death-1.0.0.tgz"
         },
         "debug": {
-          "version": "2.4.4",
+          "version": "2.6.0",
           "from": "debug@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.2",
@@ -371,25 +371,30 @@
                   "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
                   "dependencies": {
                     "concat-stream": {
-                      "version": "1.5.2",
+                      "version": "1.6.0",
                       "from": "concat-stream@>=1.4.7 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@>=2.0.3 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "typedarray": {
                           "version": "0.0.6",
-                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "from": "typedarray@>=0.0.6 <0.0.7",
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
-                          "version": "2.0.6",
-                          "from": "readable-stream@>=2.0.0 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                          "version": "2.2.2",
+                          "from": "readable-stream@>=2.2.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
                           "dependencies": {
+                            "buffer-shims": {
+                              "version": "1.0.0",
+                              "from": "buffer-shims@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                            },
                             "core-util-is": {
                               "version": "1.0.2",
                               "from": "core-util-is@>=1.0.0 <1.1.0",
@@ -458,9 +463,9 @@
               }
             },
             "lodash": {
-              "version": "4.17.2",
+              "version": "4.17.4",
               "from": "lodash@>=4.3.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
             },
             "mute-stream": {
               "version": "0.0.6",
@@ -648,9 +653,9 @@
           }
         },
         "node-emoji": {
-          "version": "1.4.3",
+          "version": "1.5.0",
           "from": "node-emoji@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.5.0.tgz",
           "dependencies": {
             "string.prototype.codepointat": {
               "version": "0.2.0",
@@ -660,9 +665,9 @@
           }
         },
         "node-gyp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "from": "node-gyp@>=3.2.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
           "dependencies": {
             "fstream": {
               "version": "1.0.10",
@@ -735,9 +740,9 @@
               }
             },
             "npmlog": {
-              "version": "3.1.2",
-              "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+              "version": "4.0.2",
+              "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
@@ -799,19 +804,19 @@
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
                 },
                 "gauge": {
-                  "version": "2.6.0",
-                  "from": "gauge@>=2.6.0 <2.7.0",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                  "version": "2.7.2",
+                  "from": "gauge@>=2.7.1 <2.8.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
                   "dependencies": {
                     "aproba": {
                       "version": "1.0.4",
                       "from": "aproba@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
                     },
-                    "has-color": {
-                      "version": "0.1.7",
-                      "from": "has-color@>=0.1.7 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                     },
                     "has-unicode": {
                       "version": "2.0.1",
@@ -895,44 +900,6 @@
                 }
               }
             },
-            "path-array": {
-              "version": "1.0.1",
-              "from": "path-array@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
-              "dependencies": {
-                "array-index": {
-                  "version": "1.0.0",
-                  "from": "array-index@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-                  "dependencies": {
-                    "es6-symbol": {
-                      "version": "3.1.0",
-                      "from": "es6-symbol@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-                      "dependencies": {
-                        "d": {
-                          "version": "0.1.1",
-                          "from": "d@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                        },
-                        "es5-ext": {
-                          "version": "0.10.12",
-                          "from": "es5-ext@>=0.10.11 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-                          "dependencies": {
-                            "es6-iterator": {
-                              "version": "2.0.0",
-                              "from": "es6-iterator@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
             "which": {
               "version": "1.2.12",
               "from": "which@>=1.0.0 <2.0.0",
@@ -985,9 +952,9 @@
           "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
           "dependencies": {
             "mute-stream": {
-              "version": "0.0.6",
+              "version": "0.0.7",
               "from": "mute-stream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz"
             }
           }
         },
@@ -1092,9 +1059,9 @@
                       }
                     },
                     "jsonpointer": {
-                      "version": "4.0.0",
+                      "version": "4.0.1",
                       "from": "jsonpointer@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
@@ -1401,48 +1368,9 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
           "dependencies": {
             "bl": {
-              "version": "1.1.2",
+              "version": "1.2.0",
               "from": "bl@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz"
             },
             "end-of-stream": {
               "version": "1.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2288,15 +2288,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2306,6 +2297,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "semver": "^5.0.3",
     "subcommand": "^2.0.3",
     "wreck": "^6.3.0",
-    "yarn": "methyl/yarn"
+    "yarn": "^0.18.1"
   },
   "devDependencies": {
     "code": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "semver": "^5.0.3",
     "subcommand": "^2.0.3",
     "wreck": "^6.3.0",
-    "yarn": "^0.17.10"
+    "yarn": "methyl/yarn"
   },
   "devDependencies": {
     "code": "^1.5.0",
@@ -43,7 +43,7 @@
   "scripts": {
     "lint": "eslint . bin/nsp",
     "setup-offline": "curl -sS https://api.nodesecurity.io/advisories -o advisories.json",
-    "test": "lab -a code -t 100 -I Reflect",
+    "test": "lab -a code -t 100 -I 'Reflect,__core-js_shared__'",
     "nsp": "bin/nsp check",
     "shrinkwrap": "npm shrinkwrap && shrinkydink"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nsp",
   "description": "The Node Security (nodesecurity.io) command line interface",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "author": "^lift security",
   "bin": {
     "nsp": "bin/nsp"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "rc": "^1.1.2",
     "semver": "^5.0.3",
     "subcommand": "^2.0.3",
-    "wreck": "^6.3.0"
+    "wreck": "^6.3.0",
+    "yarn": "^0.17.10"
   },
   "devDependencies": {
     "code": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "nsp": "bin/nsp"
   },
   "dependencies": {
+    "@yarnpkg/lockfile": "^1.0.0",
     "chalk": "^1.1.1",
     "cli-table": "^0.3.1",
     "cvss": "^1.0.0",
@@ -17,8 +18,7 @@
     "rc": "^1.1.2",
     "semver": "^5.0.3",
     "subcommand": "^2.0.3",
-    "wreck": "^6.3.0",
-    "yarn": "^0.18.1"
+    "wreck": "^6.3.0"
   },
   "devDependencies": {
     "code": "^1.5.0",

--- a/test/data/package-lock.json
+++ b/test/data/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "demo",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,  
+  "dependencies": {
+    "nsp": {
+      "version": "0.1.1",
+      "dependencies": {
+        "marked": {
+          "version": "4.0.0"
+        }
+      }
+    },
+    "marked": {
+      "version": "0.3.3"
+    },
+    "dummy": {
+      "version": "0.0.0"
+    }
+  }
+}

--- a/test/data/yarn.circular.lock
+++ b/test/data/yarn.circular.lock
@@ -1,0 +1,43 @@
+nsp@^2.0.0:
+  version "0.1.1"
+  dependencies:
+    marked "4.0.0"
+    request "^2.79"
+    babel-core "^6.0.0"
+
+nsp@^2.0.1:
+  version "0.1.1"
+  dependencies:
+    marked "4.0.0"
+    request "^2.81.0"
+
+marked@0.3.3:
+  version "0.3.3"
+  dependencies:
+    request "~2.9.1"
+
+marked@4.0.0:
+  version "4.0.0"
+  dependencies:
+    request "~2.9.1"
+
+dummy@0.0.0:
+  version "0.0.0"
+
+request@~2.9.1:
+  version "2.9.202"
+
+request@2.81.0, request@^2.79, request@^2.81.0:
+  version "2.81.0"
+
+babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
+  dependencies:
+    babel-register "^6.26.0"
+
+babel-register@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
+  dependencies:
+    babel-core "^6.26.0"

--- a/test/data/yarn.lock
+++ b/test/data/yarn.lock
@@ -1,0 +1,10 @@
+nsp@^2.0.0:
+  version "0.1.1"
+  dependencies:
+    marked "4.0.0"
+
+marked:
+  version "0.3.3"
+
+dummy:
+  version "0.0.0"

--- a/test/data/yarn.lock
+++ b/test/data/yarn.lock
@@ -2,14 +2,24 @@ nsp@^2.0.0:
   version "0.1.1"
   dependencies:
     marked "4.0.0"
+    request "^2.79.0"
 
 nsp@^2.0.1:
   version "0.1.1"
   dependencies:
     marked "4.0.0"
+    request "^2.81.0"
 
 marked:
   version "0.3.3"
+  dependencies:
+    request "~2.9.1"
 
 dummy:
   version "0.0.0"
+
+request@~2.9.1:
+  version "2.9.202"
+
+request@2.81.0, request@^2.79, request@^2.81.0:
+  version "2.81.0"

--- a/test/data/yarn.lock
+++ b/test/data/yarn.lock
@@ -3,6 +3,11 @@ nsp@^2.0.0:
   dependencies:
     marked "4.0.0"
 
+nsp@^2.0.1:
+  version "0.1.1"
+  dependencies:
+    marked "4.0.0"
+
 marked:
   version "0.3.3"
 

--- a/test/data/yarn.outdated.lock
+++ b/test/data/yarn.outdated.lock
@@ -10,11 +10,6 @@ nsp@^2.0.1:
     marked "4.0.0"
     request "^2.81.0"
 
-marked@0.3.3:
-  version "0.3.3"
-  dependencies:
-    request "~2.9.1"
-
 marked@4.0.0:
   version "4.0.0"
   dependencies:

--- a/test/unit.js
+++ b/test/unit.js
@@ -113,8 +113,8 @@ describe('check', function () {
   it('Responds correctly to receiving a 200 and findings for yarn', function (done) {
     var options = {
       package: workingOptions.package,
-      yarnlock: Path.resolve(__dirname, './data/yarn.lock'),
-    }
+      yarnlock: Path.resolve(__dirname, './data/yarn.lock')
+    };
 
     Nock('https://api.nodesecurity.io')
       .post('/check')

--- a/test/unit.js
+++ b/test/unit.js
@@ -120,6 +120,7 @@ describe('check', function () {
   });
 
   it('Responds correctly to receiving a 200 and findings for yarn', function (done) {
+
     var options = {
       package: workingOptions.package,
       yarnlock: Path.resolve(__dirname, './data/yarn.lock')
@@ -228,6 +229,7 @@ describe('check', function () {
     };
 
     Check(options, function (err, results) {
+
       expect(err).to.not.exist();
       expect(results).to.exist();
       done();
@@ -246,6 +248,7 @@ describe('check', function () {
     };
 
     Check(options, function (err, results) {
+
       expect(err).to.not.exist();
       expect(results).to.exist();
       done();

--- a/test/unit.js
+++ b/test/unit.js
@@ -235,23 +235,6 @@ describe('check', function () {
     });
   });
 
-  // it('works offline with shrinkwrap object', function (done) {
-
-  //   var options = {
-  //     shrinkwrap: require(workingOptions.shrinkwrap),
-  //     exceptions: exceptions,
-  //     advisoriesPath: Path.resolve(process.cwd(), './test/data/advisories.json'),
-  //     offline: true
-  //   };
-
-  //   Check(options, function (err, results) {
-
-  //     expect(err).to.not.exist();
-  //     expect(results).to.exist();
-  //     done();
-  //   });
-  // });
-
   it('Responds correctly to validation errors', function (done) {
 
     Nock('https://api.nodesecurity.io')

--- a/test/unit.js
+++ b/test/unit.js
@@ -173,7 +173,24 @@ describe('check', function () {
     };
 
     Check(options, function (err, results) {
+      expect(err).to.not.exist();
+      expect(results).to.exist();
+      done();
+    });
+  });
 
+  it('works offline with yarn.lock', function (done) {
+
+    var options = {
+      package: workingOptions.package,
+      shrinkwrap: Path.resolve(__dirname, './data/not-existing.json'),
+      yarnlock: Path.resolve(__dirname, './data/yarn.lock'),
+      exceptions: exceptions,
+      advisoriesPath: './test/data/advisories.json',
+      offline: true
+    };
+
+    Check(options, function (err, results) {
       expect(err).to.not.exist();
       expect(results).to.exist();
       done();

--- a/test/unit.js
+++ b/test/unit.js
@@ -90,13 +90,14 @@ describe('check', function () {
       done();
     });
   });
-  
+
   it('Responds correctly to yarn.lock being outdated', function (done) {
 
-    Check({ 
-      package: workingOptions.package, 
+    Check({
+      package: workingOptions.package,
       yarnlock: Path.resolve(__dirname, './data/yarn.outdated.lock')
     }, function (err) {
+
       var expected = 'yarn.lock is outdated';
       expect(err.message.substr(0, expected.length)).to.equal(expected);
       done();

--- a/test/unit.js
+++ b/test/unit.js
@@ -46,7 +46,7 @@ describe('check', function () {
 
     Check({ package: '../package.json', shrinkwrap: './npm-shrinkwrap.json', offline: true }, function (err) {
 
-      expect(err.message).to.equal('npm-shrinkwrap.json is required for offline mode');
+      expect(err.message).to.equal('npm-shrinkwrap.json / yarn.lock is required for offline mode');
       done();
     });
   });
@@ -103,6 +103,24 @@ describe('check', function () {
       .reply(200, Findings);
 
     Check(workingOptions, function (err, results) {
+
+      expect(err).to.not.exist();
+      expect(results).to.deep.include(Findings);
+      done();
+    });
+  });
+
+  it('Responds correctly to receiving a 200 and findings for yarn', function (done) {
+    var options = {
+      package: workingOptions.package,
+      yarnlock: Path.resolve(__dirname, './data/yarn.lock'),
+    }
+
+    Nock('https://api.nodesecurity.io')
+      .post('/check')
+      .reply(200, Findings);
+
+    Check(options, function (err, results) {
 
       expect(err).to.not.exist();
       expect(results).to.deep.include(Findings);

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Fs = require('fs');
 var Code = require('code');
 var Lab = require('lab');
 var Nock = require('nock');
@@ -7,6 +8,7 @@ var Path = require('path');
 var Check = require('../lib/check.js');
 var Pkg = require('../package.json');
 var SanitizePackage = require('../lib/utils/sanitizePackage.js');
+var Yarn = require('../lib/utils/yarn.js');
 
 var lab = exports.lab = Lab.script();
 var describe = lab.describe;
@@ -102,6 +104,19 @@ describe('check', function () {
       expect(err.message.substr(0, expected.length)).to.equal(expected);
       done();
     });
+  });
+
+  it('Responds correctly to yarn.lock with circular (dev) dependencies', function (done) {
+
+    try {
+      Yarn.parse(
+        Fs.readFileSync(Path.resolve(__dirname, './data/yarn.circular.lock'), { encoding: 'utf8' }),
+        SanitizePackage(require(Path.resolve(__dirname, './data/package.json')))
+      );
+      done();
+    } catch (err) {
+      expect(err).to.not.exist();
+    }
   });
 
   it('Responds correctly to receiving a 200 but no findings', function (done) {

--- a/test/unit.js
+++ b/test/unit.js
@@ -90,6 +90,18 @@ describe('check', function () {
       done();
     });
   });
+  
+  it('Responds correctly to yarn.lock being outdated', function (done) {
+
+    Check({ 
+      package: workingOptions.package, 
+      yarnlock: Path.resolve(__dirname, './data/yarn.outdated.lock')
+    }, function (err) {
+      var expected = 'yarn.lock is outdated';
+      expect(err.message.substr(0, expected.length)).to.equal(expected);
+      done();
+    });
+  });
 
   it('Responds correctly to receiving a 200 but no findings', function (done) {
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -114,7 +114,8 @@ describe('check', function () {
         SanitizePackage(require(Path.resolve(__dirname, './data/package.json')))
       );
       done();
-    } catch (err) {
+    }
+    catch (err) {
       expect(err).to.not.exist();
     }
   });

--- a/usage/check.txt
+++ b/usage/check.txt
@@ -1,6 +1,6 @@
 nsp check
 
-  checks a package.json / npm-shrinkwrap.json for known vulnerabilities against the Node Security API. Non-public and repository based dependencies are currently skipped.
+  checks a package.json / npm-shrinkwrap.json / yarn.lock for known vulnerabilities against the Node Security API. Non-public and repository based dependencies are currently skipped.
 
 Parameters
 
@@ -24,4 +24,3 @@ Parameters
   --warn-only: optional
 
     report errors, but always quit with an exit code of 0
-


### PR DESCRIPTION
Going forward from #142...

Still does not work correctly. In my production scenario it does not detect request~2.9.x being used. It might have something to do with yarn creating a flat list in the lock file with keys like `request~2.9.1` versus shrinkwrap which contains keys like `request` with nested `dependency` fields. The flat list can't be converted as there might be duplicates. We need to somehow make a rich list again.