### PR TITLE
use strip-json-comments to allow comments in .nsprc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The URLs used in the array should match the advisory link that the CLI reports. 
 
 Be careful using this feature. If you add code later that is impacted by an excluded advisory, Node Security has no way of knowing. Keep a careful eye on your exceptions.
 
-`.nsprc` is read using [rc](https://github.com/dominictarr/rc), so it supports comments using [json-strip-comments](https://github.com/sindresorhus/strip-json-comments).
+`.nsprc` is read using [json-strip-comments](https://github.com/sindresorhus/strip-json-comments), so comment away.
 
 ## Proxy Support
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -6,6 +6,7 @@ const Path = require('path');
 
 const Preprocessor = require('./preprocessor');
 const Reporters = require('../reporters');
+const jsonStripComments = require('strip-json-comments');
 
 const internals = {};
 internals.wrapReporter = function (name, fn, ...args) {
@@ -42,7 +43,7 @@ exports.wrap = function (name, handler) {
 
     let userConfig;
     try {
-      userConfig = JSON.parse(Fs.readFileSync(Path.join(Os.homedir(), '.nsprc')));
+      userConfig = JSON.parse(jsonStripComments(Fs.readFileSync(Path.join(Os.homedir(), '.nsprc'), {encoding: 'utf8'})));
     }
     catch (err) {}
 
@@ -52,7 +53,7 @@ exports.wrap = function (name, handler) {
 
     let config;
     try {
-      config = JSON.parse(Fs.readFileSync(Path.join(args.path, '.nsprc')));
+      config = JSON.parse(jsonStripComments(Fs.readFileSync(Path.join(args.path, '.nsprc'), {encoding: 'utf8'})));
     }
     catch (err) {}
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -6,7 +6,7 @@ const Path = require('path');
 
 const Preprocessor = require('./preprocessor');
 const Reporters = require('../reporters');
-const jsonStripComments = require('strip-json-comments');
+const JsonStripComments = require('strip-json-comments');
 
 const internals = {};
 internals.wrapReporter = function (name, fn, ...args) {
@@ -43,7 +43,7 @@ exports.wrap = function (name, handler) {
 
     let userConfig;
     try {
-      userConfig = JSON.parse(jsonStripComments(Fs.readFileSync(Path.join(Os.homedir(), '.nsprc'), {encoding: 'utf8'})));
+      userConfig = JSON.parse(JsonStripComments(Fs.readFileSync(Path.join(Os.homedir(), '.nsprc'), {encoding: 'utf8'})));
     }
     catch (err) {}
 
@@ -53,7 +53,7 @@ exports.wrap = function (name, handler) {
 
     let config;
     try {
-      config = JSON.parse(jsonStripComments(Fs.readFileSync(Path.join(args.path, '.nsprc'), {encoding: 'utf8'})));
+      config = JSON.parse(JsonStripComments(Fs.readFileSync(Path.join(args.path, '.nsprc'), {encoding: 'utf8'})));
     }
     catch (err) {}
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "inquirer": "^3.3.0",
     "nodesecurity-npm-utils": "^6.0.0",
     "semver": "^5.4.1",
+    "strip-json-comments": "2.0.1",
     "wreck": "^12.5.1",
     "yargs": "^9.0.1"
   },


### PR DESCRIPTION
The ability to use comments in in .nsprc files was mentioned in the README.md but it wasn't actually working. Looks like this was an aspirational, so I added it in. Node it seemed much easier to just use strip-json-comments module directly so that's what I used. Lemme know re and feedback you have, would like to get this landed asap.