### PR TITLE
Use process.exitCode instead of process.exit()

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -22,7 +22,7 @@ internals.wrapReporter = function (name, fn, ...args) {
 
     console.error(`Error in reporter: ${name}`);
     console.error(err.stack);
-    process.exit(4);
+    process.exitCode = 4;
   });
 };
 
@@ -101,16 +101,14 @@ exports.wrap = function (name, handler) {
 
         if (name === 'check' &&
             result.data.length > 0 &&
-            !args['warn-only']) {
-
-          if (!args.threshold ||
-              (args.threshold && maxCvss > args.threshold)) {
-
-            process.exit(1);
-          }
+            !args['warn-only'] &&
+            (!args.threshold || (args.threshold && maxCvss > args.threshold))
+        ) {
+          process.exitCode = 1;
         }
-
-        process.exit(0);
+        else {
+          process.exitCode = 0;
+        }
       });
     }).catch((err) => {
 
@@ -136,11 +134,11 @@ exports.wrap = function (name, handler) {
         if (!args['warn-only']) {
           if (err.isServer) {
             if (!args['ignore-server-errors']) {
-              process.exit(2);
+              process.exitCode = 2;
             }
           }
           else {
-            process.exit(3);
+            process.exitCode = 3;
           }
         }
       });

--- a/test/check.js
+++ b/test/check.js
@@ -106,19 +106,11 @@ describe('check handler', { parallel: false }, () => {
 
   afterEach(() => {
 
-    Mock.resetExit();
     MockFs.restore();
     return server.stop();
   });
 
   it('can run a clean check', () => {
-
-    let exited = false;
-    Mock.exit((code) => {
-
-      expect(code).to.equal(0);
-      exited = true;
-    });
 
     return Check.handler({
       path: '/clean',
@@ -126,18 +118,11 @@ describe('check handler', { parallel: false }, () => {
       baseUrl: server.info.uri
     }).then(() => {
 
-      expect(exited).to.equal(true);
+      expect(process.exitCode).to.equal(0);
     });
   });
 
   it('can run a check with one finding', () => {
-
-    let exited = false;
-    Mock.exit((code) => {
-
-      expect(code).to.equal(1);
-      exited = true;
-    });
 
     return Check.handler({
       path: '/single',
@@ -145,18 +130,11 @@ describe('check handler', { parallel: false }, () => {
       baseUrl: server.info.uri
     }).then(() => {
 
-      expect(exited).to.equal(true);
+      expect(process.exitCode).to.equal(1);
     });
   });
 
   it('can run a check with multiple findings', () => {
-
-    let exited = false;
-    Mock.exit((code) => {
-
-      expect(code).to.equal(1);
-      exited = true;
-    });
 
     return Check.handler({
       path: '/multiple',
@@ -164,18 +142,11 @@ describe('check handler', { parallel: false }, () => {
       baseUrl: server.info.uri
     }).then(() => {
 
-      expect(exited).to.equal(true);
+      expect(process.exitCode).to.equal(1);
     });
   });
 
   it('can run an offline check', () => {
-
-    let exited = false;
-    Mock.exit((code) => {
-
-      expect(code).to.equal(1);
-      exited = true;
-    });
 
     return Check.handler({
       path: '/offline',
@@ -184,18 +155,11 @@ describe('check handler', { parallel: false }, () => {
       exceptions: []
     }).then(() => {
 
-      expect(exited).to.equal(true);
+      expect(process.exitCode).to.equal(1);
     });
   });
 
   it('can run a check when package.json is missing name field', () => {
-
-    let exited = false;
-    Mock.exit((code) => {
-
-      expect(code).to.equal(0);
-      exited = true;
-    });
 
     return Check.handler({
       path: '/missing_name',
@@ -203,18 +167,11 @@ describe('check handler', { parallel: false }, () => {
       baseUrl: server.info.uri
     }).then(() => {
 
-      expect(exited).to.equal(true);
+      expect(process.exitCode).to.equal(0);
     });
   });
 
   it('exits with status 3 when package.json is invalid', () => {
-
-    let exited = false;
-    Mock.exit((code) => {
-
-      expect(code).to.equal(3);
-      exited = true;
-    });
 
     return Check.handler({
       path: '/broken',
@@ -222,7 +179,7 @@ describe('check handler', { parallel: false }, () => {
       baseUrl: server.info.uri
     }).then(() => {
 
-      expect(exited).to.equal(true);
+      expect(process.exitCode).to.equal(3);
     });
   });
 });

--- a/test/login.js
+++ b/test/login.js
@@ -26,19 +26,11 @@ describe('login handler', () => {
 
   afterEach(() => {
 
-    Mock.resetExit();
     MockFs.restore();
     return server.stop();
   });
 
   it('saves token when login succeeds', () => {
-
-    let exited = false;
-    Mock.exit((code) => {
-
-      expect(code).to.equal(0);
-      exited = true;
-    });
 
     return Login.handler({
       email: 'test@user.com',
@@ -47,7 +39,7 @@ describe('login handler', () => {
       baseUrl: server.info.uri
     }).then(() => {
 
-      expect(exited).to.equal(true);
+      expect(process.exitCode).to.equal(0);
       const config = JSON.parse(Fs.readFileSync(Path.join(Os.homedir(), '.nsprc')));
       expect(config).to.be.an.object();
       expect(config.token).to.equal('thisisafaketoken');
@@ -56,13 +48,6 @@ describe('login handler', () => {
 
   it('exits with error when login fails', () => {
 
-    let exited = false;
-    Mock.exit((code) => {
-
-      expect(code).to.equal(3);
-      exited = true;
-    });
-
     return Login.handler({
       email: 'wrong@user.com',
       password: 'shouldfail',
@@ -70,7 +55,7 @@ describe('login handler', () => {
       baseUrl: server.info.uri
     }).then(() => {
 
-      expect(exited).to.equal(true);
+      expect(process.exitCode).to.equal(3);
     });
   });
 });

--- a/test/mock.js
+++ b/test/mock.js
@@ -3,24 +3,6 @@
 const Boom = require('boom');
 const Hapi = require('hapi');
 
-process._exit = process.exit;
-
-exports.exit = function (fn) {
-
-  process.exit = function (code) {
-
-    try {
-      fn(code);
-    }
-    catch (err) {}
-  };
-};
-
-exports.resetExit = function () {
-
-  process.exit = process._exit;
-};
-
 exports.log = function (state) {
 
   console._log = console.log;


### PR DESCRIPTION
This pull request replaces calls to `process.exit()` with assignments to `process.exitCode`. This is necessary because calling `process.exit()` forcibly terminates the process without waiting for streams, including stdout and stderr, to be flushed.

From https://nodejs.org/api/process.html#process_process_exit_code:
> It is important to note that calling `process.exit()` will force the process to exit as quickly as possible even if there are still asynchronous operations pending that have not yet completed fully, including I/O operations to `process.stdout` and `process.stderr`.

This caused me problems when attempting to spawn `nsp` as a child process and read the result of the JSON reporter from stdout. The output was always truncated at 8192, and some projects produced output larger than that.

See https://github.com/nodejs/node/issues/12921.