### PR TITLE
Allow --preprocessor to work with local custom preprocessors as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,21 @@ would attempt to require the module `nsp-preprocessor-example`. If the given pre
 
 ### Creating a preprocessor
 
-A custom preprocessor should be a module named with the prefix `nsp-preprocessor-`. It must export an object where each property is the name of a command executable by the `nsp` script. The value of each of these properties must
+A custom preprocessor should be a NPM module named with the prefix `nsp-preprocessor-` or a local file. It must export an object where each property is the name of a command executable by the `nsp` script. The value of each of these properties must
 be a function that accepts a single argument `args` which represents the command line arguments passed at execution time, it must return a promise modifying or extending the `args` object.
 
+Example Usage - NPM module named ```nsp-preprocessor-example```
+```
+nsp check --preprocessor example
+```
 
-Example:
+Example Usage - local preprocessor in your code directory as ```./example-preprocessor.js```
+```
+nsp check --preprocessor ./example-preprocessor.js
+```
+
+
+Example Preprocessor:
 ```js
 module.exports = {
   check: function (args) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -62,7 +62,7 @@ exports.wrap = function (name, handler) {
 
     return Promise.resolve().then(() => {
 
-      const preprocessor = Preprocessor.load(args.preprocessor);
+      const preprocessor = Preprocessor.load(args.preprocessor, args.path);
 
       return preprocessor.hasOwnProperty(name) ? preprocessor[name](args) : Promise.resolve(args);
     }).then((res) => {

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -31,12 +31,19 @@ internals.default = {
   }
 };
 
-exports.load = (name) => {
+exports.load = (name, path) => {
 
   try {
-    return require(`nsp-preprocessor-${name}`);
+    if (name){
+      try {
+        return require(`nsp-preprocessor-${name}`);
+      }
+      catch (err) {
+        //Look at the base of the user repository
+        return require(Path.join(path, name));
+      }
+    }
   }
-  catch (err) {
-    return internals.default;
-  }
+  catch (err) {}
+  return internals.default;
 };

--- a/test/preprocessor/example-preprocessor-file.js
+++ b/test/preprocessor/example-preprocessor-file.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  check: function(args) {
+    //Do some transformation
+    return args;
+  }
+};

--- a/test/preprocessor/preprocessor.js
+++ b/test/preprocessor/preprocessor.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const Preprocessor = require('../../lib/preprocessor');
+
+const Code = require('code');
+const Lab = require('lab');
+
+const { describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+const ExamplePreprocessor = require('./example-preprocessor-file.js');
+
+
+describe('preprocessor', { parallel: false }, () => {
+
+  it('can be passed undefined and run the default', (done) => {
+
+    const preprocessor = Preprocessor.load();
+
+    expect(preprocessor.check).to.not.be.undefined();
+    return done();
+  });
+
+  it('will search for a file matching the specified path', (done) => {
+
+    const repoRoot = `${__dirname}/../../`;
+    const preprocessor = Preprocessor.load('./test/preprocessor/example-preprocessor-file.js', repoRoot);
+
+    expect(preprocessor.check('test')).to.equal(ExamplePreprocessor.check('test'));
+    return done();
+  });
+});


### PR DESCRIPTION
I would like to be able to run a local custom preprocessor. for example I would like to be able to run: 
```
nsp check --preprocessor ./example-preprocessor.js
```
The pull also maintains support NPM modules.

All tests passed and README was updated.