### PR TITLE
Adjusting the output table width to 80 chars

### DIFF
--- a/reporters/table.js
+++ b/reporters/table.js
@@ -27,7 +27,7 @@ exports.check.success = function (result) {
 
     const table = new Table({
       head: ['', finding.title],
-      colWidths: [12, 68],
+      colWidths: [12, 65],
       wordWrap: true
     });
 


### PR DESCRIPTION
The default width for a standard terminal is 80 characters. cli-table2 colWidths only sets the width inside the cells without the boarders, and since there are two columns resulting in three boarders (left, middle, right), the sum for the width of the two cells need to add up to 77 for an 80 char wide table.