### PR TITLE
Format results in a separate call from check

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -7,8 +7,8 @@ const Path = require('path');
 const Preprocessor = require('./preprocessor');
 const Reporters = require('../reporters');
 
-const internals = {};
-internals.wrapReporter = function (name, fn, ...args) {
+// const internals = {};
+exports.wrapReporter = function (name, fn, ...args) {
 
   return new Promise((resolve, reject) => {
 
@@ -91,10 +91,10 @@ exports.wrap = function (name, handler) {
       else if (reporter.hasOwnProperty(name) &&
           reporter[name].hasOwnProperty('success')) {
 
-        output = internals.wrapReporter(args.reporter, reporter[name].success, result, args);
+        output = this.wrapReporter(args.reporter, reporter[name].success, result, args);
       }
       else {
-        output = internals.wrapReporter(args.reporter, reporter.success, result, args);
+        output = this.wrapReporter(args.reporter, reporter.success, result, args);
       }
 
       return output.then(() => {
@@ -125,10 +125,10 @@ exports.wrap = function (name, handler) {
       else if (reporter.hasOwnProperty(name) &&
           reporter[name].hasOwnProperty('error')) {
 
-        output = internals.wrapReporter(args.reporter, reporter[name].error, err, args);
+        output = this.wrapReporter(args.reporter, reporter[name].error, err, args);
       }
       else {
-        output = internals.wrapReporter(args.reporter, reporter.error, err, args);
+        output = this.wrapReporter(args.reporter, reporter.error, err, args);
       }
 
       return output.then(() => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@ const Path = require('path');
 const API = require('../lib/api');
 const Offline = require('../lib/offline');
 const Package = require('../lib/package');
+const Reporters = require('../reporters');
+const Commands = require('../commands');
 
 exports.sanitizeParameters = function (args) {
 
@@ -39,6 +41,12 @@ exports.sanitizeParameters = function (args) {
 
   return result;
 };
+
+exports.reporter = function(reporterName, vulnerabilities, args) {
+  const reporter = Reporters.load(reporterName);
+  vulnerabilities
+  Command.wrapReporter(reportName, reporter['check'].success, vulnerabilities, args)
+}
 
 exports.check = function (args) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const API = require('../lib/api');
 const Offline = require('../lib/offline');
 const Package = require('../lib/package');
 const Reporters = require('../reporters');
-const Commands = require('../commands');
+const Command = require('./command');
 
 exports.sanitizeParameters = function (args) {
 
@@ -42,10 +42,9 @@ exports.sanitizeParameters = function (args) {
   return result;
 };
 
-exports.reporter = function(reporterName, vulnerabilities, args) {
+exports.reporter = function(reporterName, checkResults) {
   const reporter = Reporters.load(reporterName);
-  vulnerabilities
-  Command.wrapReporter(reportName, reporter['check'].success, vulnerabilities, args)
+  Command.wrapReporter(reporterName, reporter['check'].success, checkResults)
 }
 
 exports.check = function (args) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,9 +43,10 @@ exports.sanitizeParameters = function (args) {
 };
 
 exports.reporter = function(reporterName, checkResults) {
+
   const reporter = Reporters.load(reporterName);
-  Command.wrapReporter(reporterName, reporter['check'].success, checkResults)
-}
+  Command.wrapReporter(reporterName, reporter.check.success, checkResults);
+};
 
 exports.check = function (args) {
 


### PR DESCRIPTION
Upgrading from nsp 2.x to 3.x, the ability to format the results in a separate call from the check was lost. For my projects work flow it is important to able to do this. This PR adds that ability back. 