### PR TITLE
Warn if preprocessor does not exist

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -37,6 +37,9 @@ exports.load = (name) => {
     return require(`nsp-preprocessor-${name}`);
   }
   catch (err) {
+    if (name) {
+      console.log(`Warning: unable to load nsp-preprocessor-${name}`);
+    }
     return internals.default;
   }
 };


### PR DESCRIPTION
Currently there is no way to tell if the specified preprocessor ran or that nsp was unable to load it. This PR fixes the behaviour to show a warning to the user about the failed require.