### PR TITLE
Fix comments support in .nsprc

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The URLs used in the array should match the advisory link that the CLI reports. 
 
 Be careful using this feature. If you add code later that is impacted by an excluded advisory, Node Security has no way of knowing. Keep a careful eye on your exceptions.
 
-`.nsprc` is read using [rc](https://github.com/dominictarr/rc), so it supports comments using [json-strip-comments](https://github.com/sindresorhus/strip-json-comments).
+`.nsprc` is read using [strip-json-comments](https://github.com/sindresorhus/strip-json-comments), so comment away.
 
 ## Proxy Support
 

--- a/contributing.md
+++ b/contributing.md
@@ -3,6 +3,7 @@
 When making a pull request for this repo, please make sure of a few things
 
 - tests and linting should pass for you locally. We have CI tests that also enforce this.
+- version of the testing library `lab` used is 14, after which there were breaking changes, so correct documentation is [here](https://github.com/hapijs/lab/blob/v14.x.x/README.md)
 - rebuild the shrinkwrap file if you're changing any dependencies.
 
 ## Rebuilding the shrinkwrap

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const Fs = require('fs');
-const Os = require('os');
 const Path = require('path');
 
 const Preprocessor = require('./preprocessor');
 const Reporters = require('../reporters');
+const Config = require('./config');
 
 const internals = {};
 internals.wrapReporter = function (name, fn, ...args) {
@@ -38,23 +37,13 @@ exports.wrap = function (name, handler) {
       args.baseUrl = 'https://api.nodesecurity.io';
     }
 
-    args.path = args.path ? Path.resolve(args.path) : process.cwd();
-
-    let userConfig;
-    try {
-      userConfig = JSON.parse(Fs.readFileSync(Path.join(Os.homedir(), '.nsprc')));
-    }
-    catch (err) {}
+    const userConfig = Config.read();
 
     if (userConfig) {
       Object.assign(args, userConfig);
     }
 
-    let config;
-    try {
-      config = JSON.parse(Fs.readFileSync(Path.join(args.path, '.nsprc')));
-    }
-    catch (err) {}
+    const config = Config.read({ path: args.path ? Path.resolve(args.path) : process.cwd() });
 
     if (config) {
       Object.assign(args, config);

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,17 +3,29 @@
 const Fs = require('fs');
 const Os = require('os');
 const Path = require('path');
+const StripJsonComments = require('strip-json-comments');
+
+const configFile = '.nsprc';
+const configPath = Os.homedir();
+
+const read = function (settings = {}) {
+
+  const defaults = {
+    path: configPath,
+    file: configFile
+  };
+  const { path, file } = Object.assign({}, defaults, settings);
+  try {
+    return JSON.parse(StripJsonComments(
+      Fs.readFileSync(Path.join(path, file), { encoding: 'utf8' })
+    ));
+  }
+  catch (err) {}
+};
 
 exports.update = function (settings) {
 
-  const path = Path.join(Os.homedir(), '.nsprc');
-  let current;
-  try {
-    current = JSON.parse(Fs.readFileSync(path));
-  }
-  catch (err) {
-    current = {};
-  }
+  const current = read() || {};
 
   const updated = Object.assign(current, settings);
   for (const key in updated) {
@@ -23,7 +35,9 @@ exports.update = function (settings) {
   }
 
   try {
-    Fs.writeFileSync(path, JSON.stringify(updated, null, 2));
+    Fs.writeFileSync(Path.join(configPath, configFile), JSON.stringify(updated, null, 2));
   }
   catch (err) {}
 };
+
+exports.read = read;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const Path = require('path');
 const API = require('../lib/api');
 const Offline = require('../lib/offline');
 const Package = require('../lib/package');
+const Config = require('../lib/config');
 
 exports.sanitizeParameters = function (args) {
 
@@ -17,21 +18,13 @@ exports.sanitizeParameters = function (args) {
   result['warn-only'] = args.hasOwnProperty('warn-only') ? args['warn-only'] : false;
   result.exceptions = args.exceptions || [];
 
-  let userConfig;
-  try {
-    userConfig = JSON.parse(Fs.readFileSync(Path.join(Os.homedir(), '.nsprc')));
-  }
-  catch (err) {}
+  const userConfig = Config.read();
 
   if (userConfig) {
     Object.assign(result, userConfig);
   }
 
-  let config;
-  try {
-    config = JSON.parse(Fs.readFileSync(Path.join(result.path, '.nsprc')));
-  }
-  catch (err) {}
+  const config = Config.read({ path: result.path });
 
   if (config) {
     Object.assign(result, config);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nsp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nsp",
   "description": "The Node Security (nodesecurity.io) command line interface",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "author": "^lift security",
   "bin": {
     "nsp": "bin/nsp"
@@ -14,6 +14,7 @@
     "inquirer": "^3.3.0",
     "nodesecurity-npm-utils": "^6.0.0",
     "semver": "^5.4.1",
+    "strip-json-comments": "^2.0.1",
     "wreck": "^12.5.1",
     "yargs": "^9.0.1"
   },

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const Path = require('path');
+const { expect } = require('code');
+const { describe, it } = exports.lab = require('lab').script();
+
+const Config = require('../lib/config');
+
+describe('Config', () => {
+
+  it('should not explode when user config not found', (done) => {
+
+    expect(Config.read({ path: '/wrong/path', file: '.wrong-file' })).to.equal(undefined);
+    done();
+  });
+
+  it('should return user config stripping the comments', (done) => {
+
+    const configPath = Path.resolve(process.cwd(), './test/configs/');
+    const expectedConfig = require('./configs/stripped');
+    expect(Config.read({ path: configPath })).to.equal(expectedConfig);
+    done();
+  });
+});

--- a/test/configs/.nsprc
+++ b/test/configs/.nsprc
@@ -1,0 +1,5 @@
+{
+  // comment line
+  "key": "value",
+  "array": [] /* block comment */
+}

--- a/test/configs/stripped.json
+++ b/test/configs/stripped.json
@@ -1,0 +1,4 @@
+{
+  "key": "value",
+  "array": []
+}

--- a/test/login.js
+++ b/test/login.js
@@ -1,12 +1,10 @@
 'use strict';
 
 const Login = require('../commands/login');
+const Config = require('../lib/config');
 
-const Fs = require('fs');
 const Mock = require('./mock');
 const MockFs = require('mock-fs');
-const Os = require('os');
-const Path = require('path');
 
 const Code = require('code');
 const Lab = require('lab');
@@ -48,7 +46,7 @@ describe('login handler', () => {
     }).then(() => {
 
       expect(exited).to.equal(true);
-      const config = JSON.parse(Fs.readFileSync(Path.join(Os.homedir(), '.nsprc')));
+      const config = Config.read();
       expect(config).to.be.an.object();
       expect(config.token).to.equal('thisisafaketoken');
     });


### PR DESCRIPTION
Based on PR #210, but made it properly this time, cause there are several more places where config is being read and comments have to be stripped. So I've extracted the reading function to the `lib/config.js` and use it from other files.

Also added tests for different use cases.